### PR TITLE
Add source watcher for JS; Closes #6

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,52 +1,30 @@
 var gulp = require('gulp');
 var concat = require('gulp-concat');
-var uglify = require('gulp-uglify');
-var rename = require('gulp-rename');
 var path = require('path');
-var plumber = require('gulp-plumber');
 var runSequence = require('run-sequence');
 var webserver = require('gulp-webserver');
 
-/**
- * File patterns
- **/
 
-// Root directory
-var rootDirectory = path.resolve('./');
-
-// Source directory for build process
-var sourceDirectory = path.join(rootDirectory, './src');
-
-// tests
-var testDirectory = path.join(rootDirectory, './test/unit');
-
+var rootDirectory = path.resolve('.');
+var sourceDirectory = path.join(rootDirectory, 'src');
+var testDirectory = path.join(rootDirectory, 'test/unit');
 var sourceFiles = [
-
-  // Make sure module files are handled first
   path.join(sourceDirectory, '/**/*.module.js'),
-
-  // Then add all JavaScript files
   path.join(sourceDirectory, '/**/*.js')
 ];
 
 gulp.task('build', function() {
   gulp.src(sourceFiles)
-    .pipe(plumber())
     .pipe(concat('bridge.js'))
-    .pipe(gulp.dest('./dist/'))
-    .pipe(uglify())
-    .pipe(rename('bridge.min.js'))
-    .pipe(gulp.dest('./dist'));
+    .pipe(gulp.dest('dist/'));
 });
 
-gulp.task('webserver', function() { 
-    gulp.src('.')
-        .pipe(webserver({
-            fallback: 'index.html',
-            open: true 
-        }
-    ));
+gulp.task('webserver', function() {
+  gulp.src(rootDirectory)
+    .pipe(webserver({fallback: 'index.html', open: true}));
 });
+
+gulp.watch('src/**/*.js', ['build']);
 
 gulp.task('default', function () {
   runSequence('build', 'webserver');


### PR DESCRIPTION
This simplifies the gulp file and includes a watcher task to rebuild source on changes. If a file changes in the src directory it will rebuild.

/cc @mkinsey 