### PR TITLE
Integration of bridge and engine

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,8 @@ var sourceDirectory = path.join(rootDirectory, 'src');
 var testDirectory = path.join(rootDirectory, 'test/unit');
 var sourceFiles = [
   path.join(sourceDirectory, '/**/*.module.js'),
-  path.join(sourceDirectory, '/**/*.js')
+  path.join(sourceDirectory, '/**/*.js'),
+  path.join(sourceDirectory, '/../../engine/src/*.js')
 ];
 
 gulp.task('build', function() {

--- a/src/bridge/directives/br-fps-counter.js
+++ b/src/bridge/directives/br-fps-counter.js
@@ -9,11 +9,12 @@ angular.module('bridge.directives')
       intervalId = $interval(function() {
         var state = eventPump.paused ? 'Paused' : 'Running';
         element.text('State: ' + state + ' FPS: ' + count);
-
+        eventPump.simulator.printState(); // I want to move this to simulator_pump.js
         count = 0;
       }, 1000);
 
       var updateCallback = eventPump.register(function() {
+        eventPump.simulator.update(0.015); // I want to move this to simulator_pump.js
         count++;
       });
 

--- a/src/bridge/directives/simulator_pump.js
+++ b/src/bridge/directives/simulator_pump.js
@@ -1,16 +1,16 @@
 
 angular.module('bridge.directives')
-  .directive('simulation_pump', ['$interval', 'eventPump', function($interval, eventPump) {
+  .directive('simulation', ['$interval', 'eventPump', function($interval, eventPump) {
 
     function link(scope, element) {
       var intervalId;
 
       intervalId = $interval(function() {
-        eventPump.simulator.printState();
+        //eventPump.simulator.printState(); //Don't know why this directive isn't getting called
       }, 1000);
 
       var updateCallback = eventPump.register(function() {
-        eventPump.simulator.update(0.015);
+        //eventPump.simulator.update(0.015); //Don't know why this directive isn't getting called
       });
 
       eventPump.resume();

--- a/src/bridge/directives/simulator_pump.js
+++ b/src/bridge/directives/simulator_pump.js
@@ -1,0 +1,27 @@
+
+angular.module('bridge.directives')
+  .directive('simulation_pump', ['$interval', 'eventPump', function($interval, eventPump) {
+
+    function link(scope, element) {
+      var intervalId;
+
+      intervalId = $interval(function() {
+        eventPump.simulator.printState();
+      }, 1000);
+
+      var updateCallback = eventPump.register(function() {
+        eventPump.simulator.update(0.015);
+      });
+
+      eventPump.resume();
+
+      element.on('destroy', function() {
+        eventPump.unregister(updateCallback);
+        $interval.cancel(intervalId);
+      });
+    }
+
+    return {
+      link: link
+    };
+  }]);

--- a/src/bridge/services/eventPump.js
+++ b/src/bridge/services/eventPump.js
@@ -2,6 +2,7 @@
 function EventPump() {
   this.observers = [];
   this.paused = true;
+  this.simulator = new Simulator();
 }
 
 EventPump.prototype.register = function(callback) {


### PR DESCRIPTION
The bridge will now work with current versions of the engine. I added a path to the engine/src/*.js files to the bridge's gulpfile. Now, the fps counter directive also pumps the simulator and prints the state to the console in one second intervals. The engine folder should be placed next to the bridge folder, and everything should work from that point. I'll update the readme in the engine repo to match. 