### PR TITLE
Integrate Engine and Bridge Repositories; Closes #16

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,9 +1,10 @@
-var gulp = require('gulp');
 var concat = require('gulp-concat');
+var gulp = require('gulp');
+var browserify = require('browserify');
 var path = require('path');
 var runSequence = require('run-sequence');
+var source = require('vinyl-source-stream');
 var webserver = require('gulp-webserver');
-
 
 var rootDirectory = path.resolve('.');
 var sourceDirectory = path.join(rootDirectory, 'src');
@@ -14,18 +15,23 @@ var sourceFiles = [
 ];
 
 gulp.task('build', function() {
-  gulp.src(sourceFiles)
+  return gulp.src(sourceFiles)
     .pipe(concat('bridge.js'))
     .pipe(gulp.dest('dist/'));
 });
 
-gulp.task('webserver', function() {
+gulp.task('browserify', ['build'], function() {
+  return browserify('./dist/bridge.js')
+    .bundle()
+    .pipe(source('app.js'))
+    .pipe(gulp.dest('dist/'));
+});
+
+gulp.task('webserver', ['build', 'browserify'], function() {
   gulp.src(rootDirectory)
     .pipe(webserver({fallback: 'index.html', open: true}));
 });
 
-gulp.watch('src/**/*.js', ['build']);
+gulp.watch('src/**/*.js', ['build', 'browserify']);
 
-gulp.task('default', function () {
-  runSequence('build', 'webserver');
-});
+gulp.task('default', ['build', 'browserify', 'webserver']);

--- a/index.html
+++ b/index.html
@@ -15,9 +15,7 @@
   <!-- Custom CSS-->
   <link href="css/template.css" rel="stylesheet">
 
-  <!--  Angular -->
-  <script src="bower_components/angular/angular.js" ></script>
-  <script src="dist/bridge.js" ></script>
+  <script src="dist/app.js" ></script>
   <script src="http://d3js.org/d3.v3.min.js"></script>
 </head>
 

--- a/package.json
+++ b/package.json
@@ -21,12 +21,19 @@
   "homepage": "https://github.com/orbitable/bridge#readme",
   "devDependencies": {
     "bower": "^1.7.7",
+    "browserify": "^13.0.0",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.0",
+    "gulp-plumber": "^0.5.0",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.5.2",
     "gulp-webserver": "^0.9.1",
-    "gulp-plumber": "^0.5.0",
-    "run-sequence": "^1.1.5"
+    "run-sequence": "^1.1.5",
+    "vinyl-source-stream": "^1.1.0",
+    "vinyl-transform": "^1.0.0"
+  },
+  "dependencies": {
+    "angular": "^1.5.0",
+    "engine": "git+https://github.com/orbitable/engine.git#issue#14/common_js_modules"
   }
 }

--- a/src/bridge/bridge.module.js
+++ b/src/bridge/bridge.module.js
@@ -1,3 +1,5 @@
+var angular = require('angular');
+
 angular.module('bridge.controllers', []);
 angular.module('bridge.services', []);
 angular.module('bridge.directives', []);
@@ -6,4 +8,9 @@ angular.module('bridge', [
     'bridge.services',
     'bridge.controllers',
     'bridge.directives'
-]);
+  ])
+  .run(function($interval, simulator) {
+     $interval(function() {
+       simulator.printState();
+     }, 1000);
+  });

--- a/src/bridge/controllers/AdminController.js
+++ b/src/bridge/controllers/AdminController.js
@@ -1,3 +1,5 @@
+var angular = require('angular');
+
 angular.module('bridge.controllers')
   .controller('adminController', function($scope) {
     $scope.admin = true;

--- a/src/bridge/controllers/UserController.js
+++ b/src/bridge/controllers/UserController.js
@@ -1,3 +1,5 @@
+var angular = require('angular');
+
 angular.module('bridge.controllers')
   .controller('userController', ['$scope', 'eventPump', function($scope, eventPump) {
       $scope.user = true;

--- a/src/bridge/directives/br-fps-counter.js
+++ b/src/bridge/directives/br-fps-counter.js
@@ -1,3 +1,4 @@
+var angular = require('angular');
 
 angular.module('bridge.directives')
   .directive('counter', ['$interval', 'eventPump', function($interval, eventPump) {

--- a/src/bridge/directives/testsvg.js
+++ b/src/bridge/directives/testsvg.js
@@ -1,3 +1,5 @@
+var angular = require('angular');
+
 angular.module('bridge.directives')
   .directive('testsvg', ['$interval', 'eventPump', function($interval, eventPump) {
 

--- a/src/bridge/services/eventPump.js
+++ b/src/bridge/services/eventPump.js
@@ -1,3 +1,4 @@
+var angular = require('angular');
 
 function EventPump() {
   this.observers = [];

--- a/src/bridge/services/simulation.js
+++ b/src/bridge/services/simulation.js
@@ -1,0 +1,17 @@
+var angular = require('angular');
+var Simulator = require('engine');
+
+angular.module('bridge.services')
+  .factory('simulator', ["eventPump", function(eventPump) {
+    var simulator = new Simulator();
+    
+    // Bind update function to event pump callback
+    eventPump.register(function() {
+      // TODO: Be able to query eventPump for current FPS to adjust dt 
+      // accordingly such that the same amount of dt accumlates per second
+      // irregardless of FSP.
+      simulator.update(0.015);
+    });
+
+    return simulator;
+  }]);


### PR DESCRIPTION
Problem
=======

The engine needs to be imported into bridge and wired up to the event pump.

Solution
========

Do it.

![do it](https://media.giphy.com/media/wi8Ez1mwRcKGI/giphy.gif)

Howto Test
==========

- Update Dependencies
  - `npm install && bower install`
- Build Source
  - `gulp`
  - This includes a new step which uses *browserify* to allow the use of
    CommonJS modules within client side code.
- Examine Application in Window
  - Press the Play button to start the eventPump
  - Observe the console and a periodic call to printState will dump the
    simulation state as it is driven by the event pump.