### PR TITLE
Pin Engine Version; Closes #27

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "angular": "^1.5.0",
-    "engine": "git+https://github.com/orbitable/engine.git#issue#14/common_js_modules"
+    "engine": "git+https://github.com/orbitable/engine.git#0.0.1"
   }
 }


### PR DESCRIPTION
Problem
=======

We are tracking master of Engine as a dep. This may introduce oops as features
are expanded.

Solution
========

Use the recent release as the pinned version.

Howto Test
==========

- [ ] Run application to ensure no regressions