### PR TITLE
Dockerize Bride for Deployment; Closes #30

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM node:4-onbuild
+EXPOSE 8000

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,7 @@ gulp.task('browserify', ['build'], function() {
 
 gulp.task('webserver', ['build', 'browserify'], function() {
   gulp.src(rootDirectory)
-    .pipe(webserver({fallback: 'index.html', open: true}));
+    .pipe(webserver({host: '0.0.0.0', fallback: 'index.html', open: true}));
 });
 
 gulp.watch('src/**/*.js', ['build', 'browserify']);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "scripts": {
+    "start": "gulp",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
Problem
=======

There no means to automatically build the project for deployment.

Solution
========

Add configuration so that an automated docker build can occur whenever there is
push to a branch or PR. This allows the demo service to reload any new additions
to the project more frequently.

This containerization stuff is kind of ancillary. You don't have to worry so
much about it. Just know it is there.

Howto Test
==========

- [ ] Confirm the [automated docker service][docker] has built a container

[docker]: https://hub.docker.com/r/orbitable/bridge/builds/