### PR TITLE
Add relative protocol URI for simulations API Call; Closes #45

### DIFF
--- a/src/bridge/services/simulation.js
+++ b/src/bridge/services/simulation.js
@@ -14,5 +14,5 @@
 
 angular.module('bridge.services')
   .factory('Simulation', ['$resource', function($resource) {
-      return $resource('http://mission-control.orbitable.tech/simulations/:id');
+      return $resource('//mission-control.orbitable.tech/simulations/:id');
   }]);


### PR DESCRIPTION
Problem
=======

When resources are requested in a mixed protocol environment the it introduces
errors in firefox. For example when serving via https and a request is made to
an http simluations api endpoint the request is rejected.

Solution
========

Use relative protocol addresses to that API calls use the same underlying
protocols.

Howto Test
==========

- [ ] Confrim local run makes an http request for the simulations/random api call
   - Open developer tools
   - Navigate to resources/network to see list of recent network requests
   - Search for the /simuations/random api call and confirm it used http as the
     protocol.