### PR TITLE
Quickfix for negative radius values

### DIFF
--- a/src/bridge/directives/bodies.js
+++ b/src/bridge/directives/bodies.js
@@ -89,7 +89,7 @@ angular.module('bridge.directives')
               return d === null ? 0 : d.position.y / 1496000000;
             })
             .attr('r', function(d) {
-              return d === null ? 0 : Math.log10(d.radius / 14960);
+              return d === null ? 0 : Math.log10((d.radius + 14961) / 14960);
             })
             .attr('fill', function(d) {
 


### PR DESCRIPTION
Added a value to d.radius to ensure it would be > 1 when divided by the sim scale.