### PR TITLE
Hookup Simulation Refresh; Closes #64

### DIFF
--- a/src/bridge/controllers/UserController.js
+++ b/src/bridge/controllers/UserController.js
@@ -13,7 +13,7 @@
  */
 
 angular.module('bridge.controllers')
-  .controller('userController', ['$scope', 'eventPump', function($scope, eventPump) {
+  .controller('userController', ['$scope', 'eventPump', 'Simulation', 'simulator',  function($scope, eventPump, Simulation, simulator) {
 
       // default state is anon. may be a better way to do this
       $scope.user = {"auth": false};
@@ -46,7 +46,7 @@ angular.module('bridge.controllers')
       };
 
       this.refresh = function() {
-        console.log("refresh");
+        Simulation.get({id: 'random'}, (s) => simulator.reset(s.bodies));
       };
 
       this.logout = function(){


### PR DESCRIPTION
Problem
=======

The only way to refresh the simuation is to reload the page. A refresh button is
defined but has no functionality.

Solution
========

Use the controller.refresh function to query mission control for a new
simulaiton and load it into the simulator.

Howto Test
==========

- [ ] Click the refresh button
- [ ] Confirm the simulation state changes