### PR TITLE
Use Correct Color Selection Function; Closes #75

### DIFF
--- a/src/bridge/directives/bodies.js
+++ b/src/bridge/directives/bodies.js
@@ -276,7 +276,7 @@ angular.module('bridge.directives')
                 d3.select(this)
                   .transition()
                   .duration(500)
-                  .attr("stroke", color_scale(index))
+                  .attr("stroke", colorScale(index))
                   .attr('stroke-width', 1);
               });
           }


### PR DESCRIPTION
Problem
=======

We missed the rename of the colorScale function.

Solution
========

Use the correct name.

Howto Test
==========

- [ ] Over a trail and notice the console has no errors