### PR TITLE
Reset Line Data on Reset; Closes #89

### DIFF
--- a/src/bridge/controllers/UserController.js
+++ b/src/bridge/controllers/UserController.js
@@ -46,7 +46,16 @@ angular.module('bridge.controllers')
       };
 
       this.refresh = function() {
-        Simulation.get({id: 'random'}, (s) => simulator.reset(s.bodies));
+        Simulation.get({id: 'random'}, function(s) {
+          simulator.reset(s.bodies);
+
+          // TODO: Global state is bad we need to resolve this
+          //
+          // Created issue [#93](https://github.com/orbitable/bridge/issues/93)
+          // to capture adding a composite object to collect rendering objects.
+          lineData = [];
+          pathIndex = [];
+        });
       };
 
       this.logout = function(){


### PR DESCRIPTION
Problem
-------

The path data should reset when a simulation resets. Existing paths will reamin after a simulation reset.

Solution
--------

Clear the global variables that store the path data.

*This is a band aid to a bigger problem.* #93 has been created to figure out a better way of storing annotation data in composition with simulaton data.

Howto Test
----------

- [ ] Activate trails on a couple of bodies
- [ ] Reset the simulation by clicking the Reset Button

- /cc @alexander-dunn