### PR TITLE
Persist User and Session State

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "angular": "^1.5.0",
+    "angular-cookies": "^1.5.3",
     "angular-resource": "^1.5.0",
     "bootstrap": "^3.3.6",
     "d3": "^3.5.16",

--- a/src/bridge/bridge.module.js
+++ b/src/bridge/bridge.module.js
@@ -23,7 +23,8 @@ angular.module('bridge', [
     'bridge.services',
     'bridge.controllers',
     'bridge.directives',
-    'bridge.filters'
+    'bridge.filters',
+    require('angular-cookies')
   ])
   .run(function($interval, Simulation, simulator, eventPump) {
     // On application load reset the simulation with the latest simulation state

--- a/src/bridge/controllers/UserController.js
+++ b/src/bridge/controllers/UserController.js
@@ -16,7 +16,7 @@ angular.module('bridge.controllers')
   .controller('userController', ['$scope', 'eventPump', 'Simulation', 'simulator', 'User',  function($scope, eventPump, Simulation, simulator, User) {
       var ctrl = this;
       $scope.l = {};
-      $scope.user = null;
+      $scope.user = User.current;
 
       // TODO: Use modal controller instead of passing functions through scope.
       $scope.register = function(usr){

--- a/src/bridge/services/user.js
+++ b/src/bridge/services/user.js
@@ -11,85 +11,87 @@
  * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
-
 angular.module('bridge.services')
-  .factory('User', ['$http', '$q', function($http, $q) {
-      var userService = {
-        current:  null,
-        session: null,
-        host: '//mission-control.orbitable.tech',
-        registerEndpoint: 'users',
-        sessionEndpoint: 'sessions'
+  .factory('User', ['$cookies', '$http', '$q', function($cookies, $http, $q) {
+
+    var USER_COOKIE_KEY = 'orbitable-user';
+    var SESSION_COOKIE_KEY = 'orbitable-session';
+
+    // TODO: Get session id and requery for values. Don't store object.
+    var userService = {
+      current: $cookies.getObject(USER_COOKIE_KEY),
+      session: $cookies.getObject(SESSION_COOKIE_KEY),
+      host: '//mission-control.orbitable.tech',
+      registerEndpoint: 'users',
+      sessionEndpoint: 'sessions'
+    };
+
+    userService.register = register;
+    userService.logout   = logout;
+    userService.login    = login;
+
+    return userService;
+
+    function register(user) {
+      var d = $q.defer();
+      var self = this;
+
+      $http.post(self.host + '/' + self.registerEndpoint, user).then(
+          function(resp) {
+            d.resolve(self.current);
+          },
+          function(err) {
+            console.warn("Failed user registration: ", err);
+            d.reject(err); 
+          });
+
+      return d.promise;
+    }
+
+    function login(username, password) {
+      var d = $q.defer();
+      var self = this;
+
+      $http.post(self.host + '/' + self.sessionEndpoint, {username: username, password: password}).then(
+          function(resp) {
+
+            self.session  = resp.data;
+            self.current = self.session.owner;
+
+            $cookies.putObject(USER_COOKIE_KEY, self.current);
+            $cookies.putObject(SESSION_COOKIE_KEY, self.session);
+
+            d.resolve(self.session.owner);
+          }, 
+          function(err) {
+            console.warn("Failed user login: ", err);
+            d.reject(err);
+          });
+
+      return d.promise;
+    }
+
+
+    function logout() {
+      // Bail if we never were logged in
+      if (this.session === null && this.current === null) return;
+
+      var d = $q.defer();
+      var self = this;
+
+      var deleteValues = function (resolveValue) {
+        self.current = null;
+        self.session = null;
+
+        $cookies.remove(USER_COOKIE_KEY);
+        $cookies.remove(SESSION_COOKIE_KEY);
+
+        d.resolve(resolveValue);
       };
 
-      userService.register = register;
-      userService.logout   = logout;
-      userService.login    = login;
+      var path = this.host + '/' + this.sessionEndpoint + '/' + this.session._id;
+      $http.delete(path, self.session).then(deleteValues, deleteValues);
 
-      return userService;
-
-      function register(user) {
-        var d = $q.defer();
-        var self = this;
-
-        $http.post(self.host + '/' + self.registerEndpoint, user).then(
-            function(resp) {
-              self.current = resp.data;
-              d.resolve(self.current);
-            },
-            function(err) {
-              console.warn("Failed user registration: ", err);
-              d.reject(err); 
-            });
-
-        return d.promise;
-      }
-      
-      function login(username, password) {
-        var d = $q.defer();
-        var self = this;
-
-        $http.post(self.host + '/' + self.sessionEndpoint, {username: username, password: password}).then(
-            function(resp) {
-
-              self.session  = resp.data;
-              self.current = self.session.owner;
-
-              d.resolve(self.session.owner);
-            }, 
-            function(err) {
-              console.warn("Failed user login: ", err);
-              d.reject(err);
-            });
-
-        return d.promise;
-      }
-
-
-      function logout() {
-        // Bail if we never were logged in
-        if (this.session === null && this.current === null) return;
-
-        var d = $q.defer();
-        var self = this;
-
-        
-        $http.delete(this.host + '/' + this.sessionEndpoint + '/' + this.session._id, self.session).then(
-            function(resp) {
-
-              self.current = null;
-              self.session = null;
-
-              d.resolve(null);
-            },
-            function(err) {
-
-              self.current = null;
-              self.session = null;
-
-              d.resolve(err);
-            });
-
-        return d.promise;
-      }
+      return d.promise;
+    }
   }]);


### PR DESCRIPTION
Problem
-------

User state and Session is stored in memory and lost on a page load. This means a
user would have to re login with every page reload.

Solution
--------

Store the session and user information in a cookie which persists across page
loads.

Howto Test
----------

- Run `npm install` angular-cookies was added as a dep.
- Run `gulp`
- Notice you are not logged in
- Create account if you don't have one
- It should log you in immediately refresh the page to confirm you remain logged
  in.
- Log out. Refresh the page to confirm you remain logged out.
- Log back in with supplied credentials. 
- Refresh the page and confirm you remain logged in as your user.

References
----------

- This closes #107