### PR TITLE
Add Travis CI Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+node_js:
+  - '0.10.33'
+before_script:
+  - 'export CHROME_BIN=chromium-browser'
+  - 'export DISPLAY=:99.0'
+  - 'sh -e /etc/init.d/xvfb start'
+  - 'npm install -g gulp'
+  - 'npm install'
+
+after_script:
+  - 'gulp test'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var gulp = require('gulp');
 var path = require('path');
 var runSequence = require('run-sequence');
 var source = require('vinyl-source-stream');
+var gutil = require('gulp-util');
 var webserver = require('gulp-webserver');
 
 var rootDirectory = path.resolve('.');
@@ -15,12 +16,6 @@ var sourceFiles = [
   path.join(sourceDirectory, '/**/*.js')
 ];
 
-gulp.task('build', function() {
-  return gulp.src(sourceFiles)
-    .pipe(concat('bridge.js'))
-    .pipe(babel({presets: ['es2015']}))
-    .pipe(gulp.dest('dist/'));
-});
 
 gulp.task('browserify', ['build'], function() {
   return browserify('./dist/bridge.js')
@@ -29,12 +24,24 @@ gulp.task('browserify', ['build'], function() {
     .pipe(gulp.dest('dist/'));
 });
 
+gulp.task('build', function() {
+  return gulp.src(sourceFiles)
+    .pipe(concat('bridge.js'))
+    .pipe(babel({presets: ['es2015']}))
+    .pipe(gulp.dest('dist/'));
+});
+
+gulp.task('test', function() {
+  gutil.log('TODO:// Write some tests');
+});
+
 gulp.task('webserver', ['build', 'browserify'], function() {
+  gulp.watch('src/**/*.js', ['build', 'browserify']);
+  gulp.watch('index.html', ['build', 'browserify']);
+
   gulp.src(rootDirectory)
     .pipe(webserver({host: '0.0.0.0',  open: true}));
 });
 
-gulp.watch('src/**/*.js', ['build', 'browserify']);
-gulp.watch('index.html', ['build', 'browserify']);
 
-gulp.task('default', ['build', 'browserify', 'webserver']);
+gulp.task('default', ['build', 'browserify', 'webserver', 'test']);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "gulp",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",
@@ -28,6 +28,7 @@
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-concat": "^2.6.0",
+    "gulp-util": "^3.0.7",
     "gulp-webserver": "^0.9.1",
     "run-sequence": "^1.1.5",
     "vinyl-source-stream": "^1.1.0",


### PR DESCRIPTION
Problem
-------

We have no way of running automated tests for the repo.

Solution
--------

Add a test task in the task runner and add configuration to have Travis CI run this task.

Howto Test
----------

- [x] Ensure Travis CI ran for this branch ([See Job #3][ci_#3])
- [ ] Ensure Travis CI runs our noop test task for this pull request ([See Job #4)[ci_#4])
    - ![1460646116](https://cloud.githubusercontent.com/assets/135916/14532831/b01f3330-021f-11e6-83c7-776f27d09d9b.png)


References
----------

- @mkinsey I will follow up with setup test runners for Angular and Integration tests.
- Closes #127

[ci_#3]: https://travis-ci.org/orbitable/bridge/builds/123078602