### PR TITLE
Add Saving/Loading Simulation From Mission Control

### DIFF
--- a/partials/simulation-list.html
+++ b/partials/simulation-list.html
@@ -1,7 +1,9 @@
-<ul>
-  <li>Simulation 1</li>
-  <li>Simulation 2</li>
-  <li>Simulation 3</li>
-  <li>Simulation 4</li>
-  <li>Simulation 5</li>
-</ul>
+<div class="container-fluid" style="margin-top: 50px; background-color: white;">
+    <h1>Simulations</h1>
+    <p>Click a simulation below to load.</p>
+  <div class="row">
+    <ul>
+      <li ng-repeat='simulation in simulations'><a href="#/s/{{simulation._id}}">{{simulation._id}}</a></li>
+    </ul>
+  </div>
+</div>

--- a/partials/simulation.html
+++ b/partials/simulation.html
@@ -23,8 +23,7 @@
                   <span class="glyphicon glyphicon-list-alt"></span>
                 </button>
                 <ul id="drop-left" class="dropdown-menu">
-                  <li><a href="#">Simulation TODO</a></li>
-                  <li><a href="#">Another Simulation</a></li>
+                  <li><a href="#/s/">All Simulations</a></li>
                 </ul>
               </div>
               <button type="button" class="btn btn-default btn-lg" data-toggle="modal"

--- a/src/bridge/bridge.module.js
+++ b/src/bridge/bridge.module.js
@@ -31,16 +31,18 @@ angular.module('bridge', [
   ])
   .config(['$routeProvider', function($routeProvider) {
     $routeProvider.when('/s/', {
-      templateUrl: 'partials/simulation-list.html'
+      templateUrl: 'partials/simulation-list.html',
+      controller: 'simulationListController'
     })
-    .when('/s/:simulation_id', {
+    .when('/s/:simulationId', {
       templateUrl: 'partials/simulation.html',
       controller: 'simulationController'
     })
-    .when('/u/:user_id/', {
-      templateUrl: 'partials/simulation-list.html'
+    .when('/u/:userId', {
+      templateUrl: 'partials/simulation-list.html',
+      controller: 'simulationListController'
     })
-    .when('/u/:user_id/:simulation_id', {
+    .when('/u/:userId/:simulationId', {
       templateUrl: 'partials/simulation.html',
       controller: 'simulationController'
     })

--- a/src/bridge/controllers/AdminController.js
+++ b/src/bridge/controllers/AdminController.js
@@ -15,7 +15,7 @@
 var angular = require('angular');
 
 angular.module('bridge.controllers')
-  .controller('adminController', ['$scope', 'Scale', 'Simulation', 'simulator', 'User', 'eventPump', '$log', function($scope, Scale, Simulation, simulator, User, eventPump, $log) {
+  .controller('adminController', ['$scope', 'Scale', 'Simulation', 'simulator', 'User', 'eventPump', '$log', '$location',  function($scope, Scale, Simulation, simulator, User, eventPump, $log, $location) {
     $scope.user = User;
 
     this.add = function() {
@@ -66,8 +66,12 @@ angular.module('bridge.controllers')
     }
 
     this.save = function() {
-      $log.debug('save function()');
+      Simulation.save({
+          bodies: simulator.bodies,
+          createdBy: User.current._id},
+        (payload) => $location.path('/s/' + payload._id));
     };
+
     this.tip = function() {
       $log.debug('tip function()');
     };

--- a/src/bridge/controllers/simulationListController.js
+++ b/src/bridge/controllers/simulationListController.js
@@ -13,12 +13,12 @@
  */
 
 angular.module('bridge.controllers')
-  .controller('simulationController', ['$scope', 'eventPump', '$routeParams', 'simulator', 'Simulation', function($scope, eventPump, $routeParams, simulator, Simulation) {
-    $scope.simulationId = $routeParams.simulationId;
+  .controller('simulationListController', ['$scope', '$routeParams','Simulation', 'UserSimulation', function($scope, $routeParams, Simulation, UserSimulation) {
+    var updateSimulations = (s) => $scope.simulations = s;
 
-    Simulation.get({id: $scope.simulationId}, function(simulation) {
-      simulator.reset(simulation.bodies);
-      eventPump.step();
-    });
-  }
-  ]);
+    if ($routeParams.userId) {
+      UserSimulation.query({id: $routeParams.userId}, updateSimulations);
+    } else {
+      Simulation.query(updateSimulations);
+    }
+  }]);

--- a/src/bridge/services/simulation.js
+++ b/src/bridge/services/simulation.js
@@ -13,6 +13,9 @@
  */
 
 angular.module('bridge.services')
+  .factory('UserSimulation', ['$resource', function($resource) {
+    return $resource('//mission-control.orbitable.tech/users/:id/simulations');
+  }])
   .factory('Simulation', ['$resource', function($resource) {
-      return $resource('//mission-control.orbitable.tech/simulations/:id');
+    return $resource('//mission-control.orbitable.tech/simulations/:id');
   }]);


### PR DESCRIPTION
Problem
-------

It is not possible to load or save a simulation to mission control form the bridge interface.

Solution
--------

Tie the Simulation and UserSimulation resource services to the UI to to get basic functionality. This allow the admin panel to save a current simulation state as well as updates the app router to load a simulation state for a given ID.

Howto Test
----------

- Visit [http://localhost:8000/#/s/random](http://localhost:8000/#/s/random)
    - [x] Confirm a random simulations loads
    - [x] Ensure you are logged in
    - [x] Click the save simulatio button
    - [x] Confirm you are redirected to the simulation route `#/s/<id>`
    - [x] Share the new link with your friends and ensure they can view the
      saved simulation.
- Visit [http://localhost:8000/#/s/](http://localhost:8000/#/s/)
    - [x] Confirm a list of simulation Id's are present
    - [x] Confirm clicking a id changes the route to `#/s/<id>`
    - [x] Confirm the simulation loads in the simulator
- Visit [http://localhost:8000/#/u/benjic](http://localhost:8000/#/u/benjic)
    - [x] Confirm a subset of the simulations occurs
    - [x] Confirm opening a simulation works
- Visit the above link but change it to your user name
    - [ ] Confirm the previously saved simulation is present

References
----------

- Closes #137
- ~~This is dependent on orbitable/mission-control#57 being deployed to confirm
  user subsets.~~
- @rjfaust This sets up the resources to get simulations lists. This PR has the
  bare minimum to get things working.
- @mkinsey This addresses one of our groups effort bullet points.