### PR TITLE
Correct Dragging of Habitable Zones

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,1 @@
+{"preset": "google"}

--- a/src/bridge/directives/simulation/bodies.js
+++ b/src/bridge/directives/simulation/bodies.js
@@ -1,91 +1,83 @@
 var angular = require('angular');
 var d3 = require('d3');
 
-angular.module('bridge.directives')
-  .directive('bodies', ['eventPump', 'simulator', 'Scale', 'User', function(eventPump, simulator, Scale, User) {
-    return {
-      scope: false,
-      link: function(scope, elem) {
+var BodiesDirective = function(eventPump, simulator, Scale, User) {
+  return {
+    scope: false,
+    link: function(scope, elem) {
 
-        var bodyGroup = d3.select(elem[0]);
-        var bodies = d3.select('#bodies');
+      var bodyGroup = d3.select(elem[0]);
+      var bodies = d3.select('#bodies');
 
-        // Set up drag
-        var drag = d3.behavior.drag().on('drag', dragmove).on('dragend', sendBody);
-
-        // visually move body
-        function dragmove(d){
-          if(eventPump.paused && User.current){
+      // Set up dragging for the bodies
+      var drag = d3.behavior.drag()
+        .on('drag', function(d) {
+          if (eventPump.paused && User.current) {
             var pt = d3.mouse(bodies[0][0]);
-            d3.select(this).attr("cx", (pt[0])).attr("cy", (pt[1]));
+            d3.select(this)
+              .attr('cx', (pt[0]))
+              .attr('cy', (pt[1]));
           }
-        }
-
-        function sendBody(d) {
-          if(eventPump.paused && User.current){
+        })
+        .on('dragend', function(d) {
+          if (eventPump.paused && User.current) {
             var pt = d3.mouse(bodies[0][0]);
             var body = {
               position: {x: Scale.x.invert(pt[0]), y: Scale.y.invert(pt[1])},
             };
             simulator.updateBody(d.id, body);
-            d3.select(this).attr("transform", "translate(" + 0 + "," + 0 + ")");
             eventPump.step();
           }
-        }
+        });
 
-
-        function update(data) {
-          var bodies = bodyGroup
+      function update(data) {
+        var bodies = bodyGroup
           .selectAll('circle')
           .data(data);
 
-
-          function drawBodies(bodies) {
-            bodies
+        function drawBodies(bodies) {
+          bodies
+            .call(drag)
             .attr('cx', (d) => scope.xScale(d.position.x))
             .attr('cy', (d) => scope.yScale(d.position.y))
             .attr('r',  (d) => scope.rScale(d.radius))
             .attr('fill', (d) => d.color)
-            .on('mousedown', function(d) {
-              d3.event.stopPropagation();
-              scope.selectedBody = d;
-              simulator.selectedBody = d;
-              $('#right-sidebar').show();
-            })
             .on('mouseover',function() {
               d3.select(this)
-              .transition()
-              .duration(500)
-              .attr('stroke', 'white')
-              .attr('stroke-width',(d) => (scope.rScale(d.radius)) + 30);
+                .transition()
+                .duration(500)
+                .attr('stroke', 'white')
+                .attr('stroke-width',(d) => (scope.rScale(d.radius)) + 30);
             })
-            .on('mouseout',function() {
-              d3.select(this)
+          .on('mouseout',function() {
+            d3.select(this)
               .transition()
               .duration(500)
               .attr('stroke-width',0);
-            })
-            .on('mousedown', function(d) {
-              d3.event.stopPropagation();
-              scope.selectedBody = d;
-              simulator.selectedBody = d;
-              $('#right-sidebar').show();
+          })
+          .on('mousedown', function(d) {
+            d3.event.stopPropagation();
+            scope.selectedBody = d;
+            simulator.selectedBody = d;
+            $('#right-sidebar').show();
 
-
-              lineData[d.id] = [];
-            });
-
-          }
-
-          drawBodies(bodies);
-          drawBodies(bodies.enter().append('circle'));
-          bodies.exit().remove();
-
-          // add drag behavior
-          d3.selectAll('circle').call(drag);
+            lineData[d.id] = [];
+          });
         }
 
-        eventPump.register(() => update(simulator.bodies));
+        drawBodies(bodies);
+        drawBodies(bodies.enter().append('circle'));
+        bodies.exit().remove();
       }
-    };
-  }]);
+
+      eventPump.register(() => update(simulator.bodies));
+    }
+  };
+};
+
+// List dependencies to be injected
+BodiesDirective.$inject = ['eventPump', 'simulator', 'Scale', 'User'];
+
+// Register Directive
+angular.module('bridge.directives')
+  .directive('bodies', BodiesDirective);


### PR DESCRIPTION
Problem
-------

A drag event entered on the habitable zone causes the center body to be
reposition with the drag. This is incorrect as the habitable zone is a function
of a body's luminosity and position. It should move with the body exclusively.

Solution
--------

The call on the d3 selection of all circles cause the body drag handle to be
bound to the habitable zone, `d3.selectAll('circle').call(drag);`. This is the
cause of the issue. The body positioning drag events should be bound to the
body as exemplified below.

**Bonus** I restructured the code to follow the Google JS coding styles as
recommended by JSCS. Enable the JSCS linter in your editor to get hints for a
concise code style.

Howto Test
----------

- [x] Confirm you are unable to drag the habitable zone
- [x] Confirm you are able to reposition bodies

Reference
---------

- Closes #143
- @orbitable/all