### PR TITLE
Event pump can update without affecting simulation

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "angular-route": "^1.5.3",
     "bootstrap": "^3.3.6",
     "d3": "^3.5.16",
-    "engine": "git+https://github.com/orbitable/engine.git#0.1.7",
+    "engine": "git+https://github.com/orbitable/engine.git#0.1.8",
     "jquery": "^2.2.1"
   }
 }

--- a/src/bridge/controllers/AdminController.js
+++ b/src/bridge/controllers/AdminController.js
@@ -35,7 +35,7 @@ angular.module('bridge.controllers')
           position: {x: Scale.x.invert(pt[0]), y: Scale.y.invert(pt[1])},
         };
         simulator.addBody(body);
-        eventPump.step();
+        eventPump.step(false,true);
 
         // clear listeners and ghost circle
         svg.on('mousemove', null);

--- a/src/bridge/controllers/BodyController.js
+++ b/src/bridge/controllers/BodyController.js
@@ -69,7 +69,7 @@ angular.module('bridge.controllers')
       if(User.current){
         $('#' + id).attr('r', 0);
         simulator.deleteBody(id);
-        eventPump.step();
+        eventPump.step(false,true);
         $('#right-sidebar').hide();
       }
     };

--- a/src/bridge/controllers/SimulationController.js
+++ b/src/bridge/controllers/SimulationController.js
@@ -18,7 +18,7 @@ angular.module('bridge.controllers')
 
     Simulation.get({id: $scope.simulationId}, function(simulation) {
       simulator.reset(simulation.bodies);
-      eventPump.step();
+      eventPump.step(false,true);
     });
   }
   ]);

--- a/src/bridge/controllers/UserController.js
+++ b/src/bridge/controllers/UserController.js
@@ -33,7 +33,7 @@ angular.module('bridge.controllers')
     this.refresh = function() {
         Simulation.get({id: 'random'}, function(s) {
           simulator.reset(s.bodies);
-          eventPump.step();
+          eventPump.step(false,true);
           $('#right-sidebar').hide();
 
           // TODO: Global state is bad we need to resolve this

--- a/src/bridge/directives/simulation/bodies.js
+++ b/src/bridge/directives/simulation/bodies.js
@@ -34,6 +34,10 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
         var bodies = bodyGroup
           .selectAll('circle')
           .data(data);
+          
+        function isSelected(body) {
+          return (body === scope.selectedBody);
+        }
 
         function drawBodies(bodies) {
           bodies
@@ -41,19 +45,20 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
             .attr('cy', (d) => scope.yScale(d.position.y))
             .attr('r',  (d) => scope.rScale(d.radius))
             .attr('fill', (d) => d.color)
+            .attr('stroke', (d) => ( isSelected(d) ? 'white' : 'darkgrey' ))
+            .attr('stroke-width',(d) => ( isSelected(d) ? (scope.rScale(d.radius) + 30) : 0 ))
             .call(drag)
             .on('mouseover',function() {
               d3.select(this)
                 .transition()
                 .duration(500)
-                .attr('stroke', 'white')
-                .attr('stroke-width',(d) => (scope.rScale(d.radius)) + 30);
+                .attr('stroke-width',(d) => scope.rScale(d.radius) + 30);
             })
           .on('mouseout',function() {
             d3.select(this)
               .transition()
               .duration(500)
-              .attr('stroke-width',0);
+              .attr('stroke-width',(d) => ( isSelected(d) ? (scope.rScale(d.radius) + 30) : 0 ));
           })
           .on('mousedown', function(d) {
             d3.event.stopPropagation();

--- a/src/bridge/directives/simulation/bodies.js
+++ b/src/bridge/directives/simulation/bodies.js
@@ -26,7 +26,7 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
               position: {x: Scale.x.invert(pt[0]), y: Scale.y.invert(pt[1])},
             };
             simulator.updateBody(d.id, body);
-            eventPump.step();
+            eventPump.step(false,true);
           }
         });
 
@@ -36,7 +36,7 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
           .data(data);
           
         function isSelected(body) {
-          return (body === scope.selectedBody);
+          return (body.id === scope.selectedBody.id);
         }
 
         function drawBodies(bodies) {
@@ -64,6 +64,7 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
             d3.event.stopPropagation();
             scope.selectedBody = d;
             simulator.selectedBody = d;
+            eventPump.step(false,true);
             $('#right-sidebar').show();
 
             lineData[d.id] = [];

--- a/src/bridge/services/eventPump.js
+++ b/src/bridge/services/eventPump.js
@@ -40,9 +40,13 @@ EventPump.prototype.pause = function() {
     this.paused = true;
 };
 
-EventPump.prototype.step = function (continious) {
+EventPump.prototype.step = function (continious,pause) {
   var pump = this;
   continious = continious || false;
+  
+  if (pause || false) {
+    this.simulator.pauseFrame = true;
+  }
 
   var animationLoop = function(timestamp) {
     pump.observers.forEach( function(callback) {


### PR DESCRIPTION
Calling eventPump.step(false,true) will update rendering without affecting simulation. This prevents unwanted simulation updating when user modifies the simulation, it also removes the issue where the simulation always starts one frame in.

TODO:

- [x] Point towards appropriate engine version

* Closes #149;