### PR TITLE
Update Page Title with Simulation Title

### DIFF
--- a/src/bridge/controllers/SimulationController.js
+++ b/src/bridge/controllers/SimulationController.js
@@ -17,6 +17,11 @@ angular.module('bridge.controllers')
     $scope.simulationId = $routeParams.simulationId;
 
     Simulation.get({id: $scope.simulationId}, function(simulation) {
+      
+      // Update the document title with the simulation title
+      document.title = 'Oribitable - ' + simulation.title;
+
+      // Update the simulator with the data
       simulator.reset(simulation.bodies);
       eventPump.step(false,true);
     });


### PR DESCRIPTION
Problem
-------

The title of the page does not reflect the currently loaded simulation.

Solution
--------

Update document title when loading a simulation.

Howto Test
----------

- [ ] Load a Simulation from the [list](http://0.0.0.0:8000/#/s/5716eef20918e010000d2275)
- [ ] Confirm simulation loads
- [ ] Look at your tab title 
- [ ] Observe it is set to `Oribitable - The Second Simulation`

References
----------

- Closes #154 
- @mkinsey This is a nice to have.