### PR TITLE
Add Guard to isSelected Function

### DIFF
--- a/src/bridge/directives/simulation/bodies.js
+++ b/src/bridge/directives/simulation/bodies.js
@@ -36,7 +36,11 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
           .data(data);
           
         function isSelected(body) {
-          return (body.id === scope.selectedBody.id);
+          if (body && scope.selectedBody ) {
+            return body.id === scope.selectedBody.id;
+          }
+
+          return false;
         }
 
         function drawBodies(bodies) {


### PR DESCRIPTION
Problem
-------

The isSelected function will fail if selectedBody on the scope is not set. This is introducing issues when initially loading a simulation.

Solution
--------

Add a guard to test if `selectedBody` is set.

References
----------

- Closes #157