### PR TITLE
Add Correct Reset Behaviour

### DIFF
--- a/partials/simulation.html
+++ b/partials/simulation.html
@@ -59,7 +59,8 @@
               <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
             </button>
             <button type="button" class="btn btn-default btn-lg" ng-click="u.togglePlay()">
-              <span class="glyphicon glyphicon-{{pump}}" aria-hidden="true"></span>
+              <span class="glyphicon" ng-class="{'glyphicon-pause': !isPaused(),
+                'glyphicon-play': isPaused()}" aria-hidden="true"></span>
             </button>
             <button id="btn_ruler" type="button" class="btn btn-lg toggleOff" ng-click="u.ruler()" >
               <img src="ruler.png" style="width:20px"/>

--- a/src/bridge/controllers/UserController.js
+++ b/src/bridge/controllers/UserController.js
@@ -13,18 +13,12 @@
  */
 
 angular.module('bridge.controllers')
-  .controller('userController', ['$scope', '$routeParams', 'eventPump', 'Simulation', 'simulator', 'User',  function($scope, $routeParams, eventPump, Simulation, simulator, User) {
-    $scope.pump = eventPump.paused ? 'play' : 'pause';
+  .controller('userController', ['$routeParams', '$scope', 'eventPump', 'Simulation', 'simulator', 'User',  function($routeParams, $scope, eventPump, Simulation, simulator, User) {
+    $scope.isPaused = () => eventPump.paused;
     $scope.User = User;
 
     this.togglePlay = function() {
-        if (eventPump.paused) {
-          eventPump.resume();
-          $scope.pump = 'pause';
-        } else {
-          eventPump.pause();
-          $scope.pump = 'play';
-        }
+        $scope.isPaused() ? eventPump.resume() : eventPump.pause();
       };
       
       this.newSimulation = function() {
@@ -34,7 +28,7 @@ angular.module('bridge.controllers')
       
     this.paused = function() {
         return eventPump.paused;
-      };
+    };
 
     this.refresh = function() {
         Simulation.get({
@@ -80,7 +74,4 @@ angular.module('bridge.controllers')
           tracker.style.visibility = "visible";
         }
       };
-      
-      
-
   }]);

--- a/src/bridge/directives/br-fps-counter.js
+++ b/src/bridge/directives/br-fps-counter.js
@@ -18,16 +18,8 @@ angular.module('bridge.directives')
   .directive('counter', ['$interval', 'eventPump', function($interval, eventPump) {
 
     function link(scope, element) {
-      var intervalId;
-      var count = 0;
-
-      intervalId = $interval(function() {
-        var state = eventPump.paused ? 'Paused' : 'Running';
-        count = 0;
-      }, 1000);
-
+     
       var updateCallback = eventPump.register(function() {
-        count++;
         element.text(Math.round(eventPump.simulator.simulationTime) + " seconds");
       });
 


### PR DESCRIPTION
Problem
-------

When a user clicks reset within bridge a random simulation is generated. The
correct behavior is to reset the currently selected simulation to it's initial
state.

Solution
--------

Check the route parameters for a simulation ID and reload the simulation with
the given ID. If none is present, load the random simulation.

Howto Test
----------

- Go to the simulation [list](http://localhost:8001/#/s/)
- Choose a simulation
- Ensure the simulation plays
- Reset the simultion and confirms it resets back to the beginning state

References
----------

- **Bonus** Cleaned up play button behaviour to be a little more DRY
- Closes #159
- Inspired an update to [engine](https://github.com/orbitable/engine/pull/73)
  which resets the simulation time as well.