### PR TITLE
Use selectedNote Scope Field for Note Selection

### DIFF
--- a/partials/note-data.html
+++ b/partials/note-data.html
@@ -6,29 +6,29 @@
   <div class="panel-body">
     <div class="input-group">
       <span class="input-group-addon" id="title-input">Title:</span>
-      <input type="text" class="form-control" placeholder="{{selectedBody.title}}" aria-describedby="title-input" ng-model="selectedBody.title" ng-change="n.updateNote()">
+      <input type="text" class="form-control" placeholder="{{selectedNote.title}}" aria-describedby="title-input" ng-model="selectedNote.title" ng-change="n.updateNote()">
     </div><br>
     <div class="input-group">
       <span class="input-group-addon" id="text-input">Text:</span>
-      <textarea type="text" rows = "3" class="form-control" placeholder="{{selectedBody.text}}" aria-describedby="text-input" ng-model="selectedBody.text" ng-change="n.updateNote()"></textarea>
+      <textarea type="text" rows = "3" class="form-control" placeholder="{{selectedNote.text}}" aria-describedby="text-input" ng-model="selectedNote.text" ng-change="n.updateNote()"></textarea>
     </div><br>
     <div class="input-group">
       <span class="input-group-addon" id="startTime-input">Start Time:</span>
-      <input type="text" class="form-control" placeholder="{{selectedBody.startTime}}" aria-describedby="startTime-input" ng-model="selectedBody.startTime" ng-change="n.updateNote()">
+      <input type="text" class="form-control" placeholder="{{selectedNote.startTime}}" aria-describedby="startTime-input" ng-model="selectedNote.startTime" ng-change="n.updateNote()">
     </div><br>
     <div class="input-group">
       <span class="input-group-addon" id="duration-input">Duration:</span>
-      <input type="text" class="form-control" placeholder="{{selectedBody.duration}}" aria-describedby="duration-input" ng-model="selectedBody.duration" ng-change="n.updateNote()">
+      <input type="text" class="form-control" placeholder="{{selectedNote.duration}}" aria-describedby="duration-input" ng-model="selectedNote.duration" ng-change="n.updateNote()">
     </div><br>
     <div class="input-group">
       <span class="input-group-addon" id="positionX-input">Position X:</span>
-      <input type="text" class="form-control" placeholder="{{selectedBody.position.x}}" aria-describedby="positionX-input" ng-model="selectedBody.position.x" ng-change="n.updateNote()">
+      <input type="text" class="form-control" placeholder="{{selectedNote.position.x}}" aria-describedby="positionX-input" ng-model="selectedNote.position.x" ng-change="n.updateNote()">
     </div>
     <div class="input-group">
       <span class="input-group-addon" id="positionY-input">Position Y:</span>
-      <input type="text" class="form-control" placeholder="{{selectedBody.position.y}}" aria-describedby="positionY-input" ng-model="selectedBody.position.y" ng-change="n.updateNote()">
+      <input type="text" class="form-control" placeholder="{{selectedNote.position.y}}" aria-describedby="positionY-input" ng-model="selectedNote.position.y" ng-change="n.updateNote()">
     </div><br>
-    <div class="text-center"><button type="button" class="btn btn-default btn" ng-click="n.removeNote(selectedBody.id)">
+    <div class="text-center"><button type="button" class="btn btn-default btn" ng-click="n.removeNote(selectedNote.id)">
       <span class="glyphicon glyphicon-trash"></span> </button> 
     </div>
   </div>

--- a/src/bridge/controllers/NoteController.js
+++ b/src/bridge/controllers/NoteController.js
@@ -1,5 +1,5 @@
 angular.module('bridge.controllers')
-  .controller('noteController', ['$scope',  'simulator', function($scope,  simulator) {
+  .controller('noteController', ['$scope', 'eventPump',  'simulator', function($scope, eventPump, simulator) {
 
     $scope.notePause = false;
     
@@ -16,12 +16,12 @@ angular.module('bridge.controllers')
     this.removeNote = function(id) {
       $('#' + id).attr('stroke-width', 0);
       simulator.deleteNote(id);
-      //eventPump.step(false,true);
+      eventPump.step(false,true);
       this.closePanel();
     };
     
     this.updateNote = function() {
-        var n = $scope.selectedBody;
+        var n = $scope.selectedNote;
         simulator.updateNote(n.id, n);
     };
 

--- a/src/bridge/directives/simulation/bodies.js
+++ b/src/bridge/directives/simulation/bodies.js
@@ -7,8 +7,8 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
     link: function(scope, elem) {
       // TODO: Properly resolve the initial resolution of selected body
       scope.selectedBody = {};
-      scope.selectedNote = {};
       scope.editingBody = {};
+      scope.selectedNote = {};
 
       // Stores the timestamp when a drag starts
       scope.dragDownTime = 0;
@@ -100,6 +100,7 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
               scope.selectedBody = d;
               scope.editingBody = scope.selectedBody.copy();
               simulator.selectedBody = d;
+              scope.selectedNote = {};
               eventPump.step(false,true);
               $('#right-sidebar').show();
               $('#note-sidebar').hide();
@@ -121,7 +122,11 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
                     .attr('style',"stroke:grey;stroke-width:2;stroke-opacity:1.0")
                     .on('mousedown', function(d) {
                         d3.event.stopPropagation();
+                        
+                        scope.selectedBody = {};
                         scope.selectedNote = d;
+                        eventPump.step(false,true);
+
                         $('#note-sidebar').show();
                         $('#right-sidebar').hide();
                     })

--- a/src/bridge/directives/simulation/bodies.js
+++ b/src/bridge/directives/simulation/bodies.js
@@ -7,6 +7,7 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
     link: function(scope, elem) {
       // TODO: Properly resolve the initial resolution of selected body
       scope.selectedBody = {};
+      scope.selectedNote = {};
       scope.editingBody = {};
 
       // Stores the timestamp when a drag starts
@@ -53,10 +54,16 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
         
         if (typeof scope.selectedBody.copy == 'function' && !eventPump.paused) {
           scope.editingBody = scope.selectedBody.copy();
-          document.getElementById('positionx').value = scope.editingBody.position.x;
-          document.getElementById('positiony').value = scope.editingBody.position.y;
-          document.getElementById('velocityx').value = scope.editingBody.velocity.x;
-          document.getElementById('velocityy').value = scope.editingBody.velocity.y;
+
+          if (scope.editingBody.position) {
+            document.getElementById('positionx').value = scope.editingBody.position.x;
+            document.getElementById('positiony').value = scope.editingBody.position.y;
+          }
+
+          if (scope.editingBody.velocity) {
+            document.getElementById('velocityx').value = scope.editingBody.velocity.x;
+            document.getElementById('velocityy').value = scope.editingBody.velocity.y;
+          }
         }
            
         function isSelected(body) {
@@ -114,8 +121,7 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
                     .attr('style',"stroke:grey;stroke-width:2;stroke-opacity:1.0")
                     .on('mousedown', function(d) {
                         d3.event.stopPropagation();
-                        scope.selectedBody = d;
-                        scope.editingBody = scope.selectedBody.copy();
+                        scope.selectedNote = d;
                         $('#note-sidebar').show();
                         $('#right-sidebar').hide();
                     })
@@ -132,13 +138,6 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
                         .duration(500)
                         .attr('stroke', 'grey')
                         .attr('stroke-width', 1);
-                    })
-                    .on('mousedown', function(d) {
-                        d3.event.stopPropagation();
-                        scope.selectedBody = d;
-                        scope.editingBody = scope.selectedBody.copy();
-                        $('#note-sidebar').show();
-                        $('#right-sidebar').hide();
                     });
             }
 


### PR DESCRIPTION
Problem
-------

When selecting a note the selected body scope object is used to hold it's
reference but this causes issues when dealing with interacting with the selected
body as if it is a body.

Solution
--------

Add an independent scope field labeled `selectedNote` which holds the handle to
the last selected note so there is no conflict between the two.

Howto Test
----------

- [ ] Pause the simulation
- [ ] Select a Note
- [ ] Resume simulation
- [ ] Confirm selected note data is correct
- [ ] Select a body
- [ ] Confirm selected body data is correct

References
----------

- Closes #179