### PR TITLE
Flag Scope as Dirty On Selection

### DIFF
--- a/src/bridge/directives/simulation/bodies.js
+++ b/src/bridge/directives/simulation/bodies.js
@@ -102,6 +102,9 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
               simulator.selectedBody = d;
               scope.selectedNote = {};
               eventPump.step(false,true);
+              
+              scope.$apply();
+
               $('#right-sidebar').show();
               $('#note-sidebar').hide();
 
@@ -126,6 +129,8 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
                         scope.selectedBody = {};
                         scope.selectedNote = d;
                         eventPump.step(false,true);
+
+                        scope.$apply();
 
                         $('#note-sidebar').show();
                         $('#right-sidebar').hide();


### PR DESCRIPTION
Problem
-------

When updating the scope object there is not explicit call to $apply which
prevents angular from diffing the scope update.

Solution
--------

Call apply when selecting a new body or note to signal to angular that the scope
has been updated. This causes any other reference to the scope to be
reevaluated.

Howto Test
----------

- [ ] Load a simulation
- [ ] Select a body
- [ ] Notice the body data panel updates
- [ ] Select a note
- [ ] Notice the selected note panel updates


References
----------

- Closes #181
- @aaroncameron21 This corrects the selection issue.