### PR TITLE
Unify Panel UX and Apperance

### DIFF
--- a/css/template.css
+++ b/css/template.css
@@ -42,42 +42,22 @@ g {
   overflow: hidden;
 }
 
-#left-sidebar{
-  width: 100%
-  height: 100%;
-  padding: 10% 0; /* adds north and south padding to "center" */
+.left-sidebar{
+  left: 0;
+  padding-left:25px;
   position: fixed;
-  bottom: 0%;
-  /*display: flex;*/
-  /*align-items: center;*/
+  top: 10%;
 }
 
-#right-sidebar{
-  width: 300px;
-  height: 100%;
-  padding: 75px 0; /* adds north and south padding to "center" */
+.right-sidebar {
+  max-width: 300px;
+  padding-right: 25px;
   position: fixed;
-  right: 0%;
-  text-align: left;
+  right: 0;
+  top: 10%;
 }
 
-#note-sidebar{
-  width: 100%
-  height: 100%;
-  max-width: 25%;
-  padding: 10% 0; /* adds north and south padding to "center" */
-  position: fixed;
-  right: 0%;
-  text-align: left;
-}
-
-#tracker-sidebar{
-  width: 100%
-  height: 100%;
-  padding: 0% 0%; /* adds north and south padding to "center" */
-  position: fixed;
-  bottom: 0%;
-  right: 0%;
+#tracker-sidebar {
   text-align: center;
 }
 
@@ -86,6 +66,7 @@ counter {
   height: 100%;
   color: white;
 }
+
 #counter{
   position: fixed;
   bottom: 0%;
@@ -154,16 +135,16 @@ counter {
   color: white;
 }
 
-.toggleOn {
+.on {
   background-color: #ffffff;
 }
 
-.toggleOff {
+.off {
   background-color: #464545;
   border-color: #464545; 
 }
 
-.toggleOff:hover {
+.off:hover {
   background-color: #e6e6e6;
   border-color: #e6e6e6;
 }

--- a/css/template.css
+++ b/css/template.css
@@ -42,19 +42,24 @@ g {
   overflow: hidden;
 }
 
+.sidebar {
+  position: fixed;
+  top: 75px;
+}
+
 .left-sidebar{
   left: 0;
   padding-left:25px;
-  position: fixed;
-  top: 10%;
+}
+
+.sidebar .nav {
+  min-width: 54px;
 }
 
 .right-sidebar {
   max-width: 300px;
   padding-right: 25px;
-  position: fixed;
   right: 0;
-  top: 10%;
 }
 
 #tracker-sidebar {
@@ -91,6 +96,7 @@ counter {
   top: 0;
   left: 100%;
 }
+
 .note
 {
     color: #ffffff;

--- a/partials/simulation-list.html
+++ b/partials/simulation-list.html
@@ -13,11 +13,13 @@
           <div ng-show='simulations'>
             <p ng-hide="simulations.length">There is no simulations to display.</p>
             <div class="media" ng-repeat='simulation in simulations'>
+              <!-- TODO:// Add simulation previews
               <div class="media-left">
                 <a href="#/s/{{simulation._id}}">
                   <img class="media-object" src="data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9InllcyI/PjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHZpZXdCb3g9IjAgMCA2NCA2NCIgcHJlc2VydmVBc3BlY3RSYXRpbz0ibm9uZSI+PCEtLQpTb3VyY2UgVVJMOiBob2xkZXIuanMvNjR4NjQKQ3JlYXRlZCB3aXRoIEhvbGRlci5qcyAyLjYuMC4KTGVhcm4gbW9yZSBhdCBodHRwOi8vaG9sZGVyanMuY29tCihjKSAyMDEyLTIwMTUgSXZhbiBNYWxvcGluc2t5IC0gaHR0cDovL2ltc2t5LmNvCi0tPjxkZWZzPjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI+PCFbQ0RBVEFbI2hvbGRlcl8xNTQyZmM2MmZiYSB0ZXh0IHsgZmlsbDojQUFBQUFBO2ZvbnQtd2VpZ2h0OmJvbGQ7Zm9udC1mYW1pbHk6QXJpYWwsIEhlbHZldGljYSwgT3BlbiBTYW5zLCBzYW5zLXNlcmlmLCBtb25vc3BhY2U7Zm9udC1zaXplOjEwcHQgfSBdXT48L3N0eWxlPjwvZGVmcz48ZyBpZD0iaG9sZGVyXzE1NDJmYzYyZmJhIj48cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIGZpbGw9IiNFRUVFRUUiLz48Zz48dGV4dCB4PSIxMy45Mjk2ODc1IiB5PSIzNi41Ij42NHg2NDwvdGV4dD48L2c+PC9nPjwvc3ZnPg==">
                 </a>
               </div>
+              -->
               <div class="media-body">
                 <a href="#/s/{{simulation._id}}">
                   <h4 class="media-heading">{{simulation.title}}</h4>

--- a/partials/simulation.html
+++ b/partials/simulation.html
@@ -20,7 +20,7 @@
   <div id="note-sidebar" class="sidebar right-sidebar" style='display: none'>
     <note-data></note-data>
   </div>
-    <div id="tracker-sidebar" class='right-sidebar' style='display: none' ng-controller="trackerController as t">
+    <div id="tracker-sidebar" class='sidebar right-sidebar' style='display: none' ng-controller="trackerController as t">
             <div class="panel panel-default">
               <div class="panel-heading text-center">
                 <h3 class='panel-title'>Orbit Tracker</h3>

--- a/partials/simulation.html
+++ b/partials/simulation.html
@@ -14,16 +14,18 @@
       </div>
     </div>
   </div>
-  <div id="right-sidebar">
+  <div id="body-sidebar" class="right-sidebar" style='display: none'>
     <body-data></body-data>
   </div>
-  <div id="note-sidebar">
+  <div id="note-sidebar" class="right-sidebar" style='display: none'>
     <note-data></note-data>
   </div>
-    <div id="tracker-sidebar" style="visibility:hidden" ng-controller="trackerController as t">
+    <div id="tracker-sidebar" class='right-sidebar' style='display: none' ng-controller="trackerController as t">
             <div class="panel panel-default">
-                <div class="panel-heading text-center"><b>Orbit Tracker</b></div>
-                <div class="panel">
+              <div class="panel-heading text-center">
+                <h3 class='panel-title'>Orbit Tracker</h3>
+              </div>
+                <div class="panel-body">
                     <h4><span class="label label-success" ng-show="t.getState()" >Running</span></h4>
                     <h4><span class="label label-warning" ng-show="!t.getState()" >Not Running</span></h4>
                     <div class="row">
@@ -50,7 +52,7 @@
                 </div>
             </div>
         </div>
-  <div id="left-sidebar">
+  <div id="left-sidebar" class='left-sidebar'>
     <nav ng-controller="userController as u">
       <ul id="user-menu" class="nav nav-stacked" >
         <li>
@@ -58,14 +60,16 @@
             <button type="button" class="btn btn-default btn-lg" ng-click="u.refresh()">
               <span class="glyphicon glyphicon-refresh" aria-hidden="true"></span>
             </button>
-            <button type="button" class="btn btn-default btn-lg" ng-click="u.togglePlay()">
+            <button type="button" class="btn btn-lg btn-default" ng-click="u.togglePlay()">
               <span class="glyphicon" ng-class="{'glyphicon-pause': !isPaused(),
                 'glyphicon-play': isPaused()}" aria-hidden="true"></span>
             </button>
-            <button id="btn_ruler" type="button" class="btn btn-lg toggleOff" ng-click="u.ruler()" >
+            <button id="btn_ruler" type="button" class="btn btn-lg off" ng-click="u.ruler()" >
               <img src="ruler.png" style="width:20px"/>
             </button>
-            <button id="btn_tracker" type="button" class="btn btn-lg toggleOff" ng-click="u.tracker()" >
+            <button id="btn_tracker" type="button" class="btn btn-lg off"
+              ng-class='{"on": trackerPanel.isOpen, "off": !trackerPanel.isOpen}'
+              ng-click="u.toggleTrackerPanel()" >
                 <img src="tracker.png" style="width:20px"/>
             </button>
             <button id="btn_new" type="button" class="btn btn-default btn-lg" ng-click="u.newSimulation()" >

--- a/partials/simulation.html
+++ b/partials/simulation.html
@@ -14,10 +14,10 @@
       </div>
     </div>
   </div>
-  <div id="body-sidebar" class="right-sidebar" style='display: none'>
+  <div id="body-sidebar" class="sidebar right-sidebar" style='display: none'>
     <body-data></body-data>
   </div>
-  <div id="note-sidebar" class="right-sidebar" style='display: none'>
+  <div id="note-sidebar" class="sidebar right-sidebar" style='display: none'>
     <note-data></note-data>
   </div>
     <div id="tracker-sidebar" class='right-sidebar' style='display: none' ng-controller="trackerController as t">
@@ -52,7 +52,7 @@
                 </div>
             </div>
         </div>
-  <div id="left-sidebar" class='left-sidebar'>
+  <div id="left-sidebar" class='sidebar left-sidebar'>
     <nav ng-controller="userController as u">
       <ul id="user-menu" class="nav nav-stacked" >
         <li>

--- a/src/bridge/controllers/BodyController.js
+++ b/src/bridge/controllers/BodyController.js
@@ -14,6 +14,8 @@
 
 angular.module('bridge.controllers')
   .controller('bodyController', ['$scope', 'eventPump', 'simulator', 'User', function($scope, eventPump, simulator, User) {
+    $scope.trackerPanel = {isOpen: false};
+
     $scope.timestep = 40000;
     $scope.timestepUnits = 'seconds';
     $scope.uDist = 'm';
@@ -70,12 +72,12 @@ angular.module('bridge.controllers')
         $('#' + id).attr('r', 0);
         simulator.deleteBody(id);
         eventPump.step(false,true);
-        $('#right-sidebar').hide();
+        $('#body-sidebar').hide();
       }
     };
 
     this.close = function() {
-      $('#right-sidebar').hide();
+      $('#body-sidebar').hide();
       $('#note-sidebar').hide();
     };
   }]);

--- a/src/bridge/controllers/UserController.js
+++ b/src/bridge/controllers/UserController.js
@@ -36,8 +36,9 @@ angular.module('bridge.controllers')
           function(s) {
             simulator.reset(s.bodies);
             eventPump.step(false,true);
-            $('#right-sidebar').hide();
+            $('#body-sidebar').hide();
             $('#note-sidebar').hide();
+            $('#tracker-sidebar').hide();
 
             // TODO: Global state is bad we need to resolve this
             //
@@ -49,29 +50,30 @@ angular.module('bridge.controllers')
 
     this.ruler = function() {
         var btn = document.getElementById('btn_ruler');
-        var index = btn.getAttribute('class').indexOf(' toggleOn');
+        var index = btn.getAttribute('class').indexOf(' on');
         var ruler = document.getElementById('rulerGroup');
         if (index > -1) {
-          btn.setAttribute('class',btn.getAttribute('class').slice(0, index) + ' toggleOff');
+          btn.setAttribute('class',btn.getAttribute('class').slice(0, index) + ' off');
           ruler.style.visibility = 'hidden';
         } else {
-          index = btn.getAttribute('class').indexOf(' toggleOff');
-          btn.setAttribute('class',btn.getAttribute('class').slice(0, index) + ' toggleOn');
+          index = btn.getAttribute('class').indexOf(' off');
+          btn.setAttribute('class',btn.getAttribute('class').slice(0, index) + ' on');
           ruler.style.visibility = 'visible';
         }
-      };
-      
-       this.tracker = function(){
-        var btn = document.getElementById("btn_tracker");
-        var index = btn.getAttribute("class").indexOf(" toggleOn");
-        var tracker = document.getElementById("tracker-sidebar");
-        if (index > -1) {
-          btn.setAttribute("class",btn.getAttribute("class").slice(0, index) + " toggleOff");
-          tracker.style.visibility = "hidden";
-        } else {
-          index = btn.getAttribute("class").indexOf(" toggleOff");
-          btn.setAttribute("class",btn.getAttribute("class").slice(0, index) + " toggleOn");
-          tracker.style.visibility = "visible";
-        }
-      };
+    };
+
+    this.toggleTrackerPanel = function() {
+
+      if ($scope.trackerPanel.isOpen) {
+        $('#tracker-sidebar').hide();
+      } else {
+        $('#body-sidebar').hide();
+        $('#note-sidebar').hide();
+
+        $('#tracker-sidebar').show();
+      }
+
+      $scope.trackerPanel.isOpen = !$scope.trackerPanel.isOpen;
+    };
+
   }]);

--- a/src/bridge/directives/simulation/bodies.js
+++ b/src/bridge/directives/simulation/bodies.js
@@ -105,8 +105,10 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
               
               scope.$apply();
 
-              $('#right-sidebar').show();
-              $('#note-sidebar').hide();
+              if (!scope.trackerPanel.isOpen) {
+                $('#body-sidebar').show();
+                $('#note-sidebar').hide();
+              }
 
               lineData[d.id] = [];
             });
@@ -133,7 +135,8 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
                         scope.$apply();
 
                         $('#note-sidebar').show();
-                        $('#right-sidebar').hide();
+                        $('#body-sidebar').hide();
+                        $('#tracker-sidebar').hide();
                     })
                     .on('mouseover',function() {
                         d3.select(this)

--- a/src/bridge/directives/simulation/body-data.js
+++ b/src/bridge/directives/simulation/body-data.js
@@ -2,8 +2,6 @@ var angular = require('angular');
 
 angular.module('bridge.directives')
   .directive('bodyData', function(){
-    $('#right-sidebar').hide();
-
     return {
       scope: false,
       templateUrl: 'partials/body-data.html'

--- a/src/bridge/directives/simulation/ruler.js
+++ b/src/bridge/directives/simulation/ruler.js
@@ -19,7 +19,7 @@ angular.module('bridge.directives')
         var rulerSet = true;
 
         scope.svg.on('click', function(d) {
-          if (rulerBtn.property('className').indexOf('toggleOn') > -1) {
+          if (rulerBtn.property('className').indexOf('on') > -1) {
             origPos = rulerSet ? d3.mouse(translation[0][0]) : origPos;
             origPos = origPos.map(p => p*scope.zoom.scale())
             rulerSet = !rulerSet;
@@ -27,7 +27,7 @@ angular.module('bridge.directives')
         });
 
         scope.svg.on('mousemove', function(d) {
-          if (rulerBtn.property('className').indexOf('toggleOn') > -1) {
+          if (rulerBtn.property('className').indexOf('on') > -1) {
             if (!rulerSet) {
               var pos = d3.mouse(translation[0][0]);
               pos = pos.map(p => p*scope.zoom.scale())


### PR DESCRIPTION
Problem
-------

The panels have differing apperance and the UX realated to how they interact is
muddled.

Solution
--------

Use css classes to unify the look of all right and left sidebars as well as
define how panels may show up.

Howto Test
----------

- [x] Confirm no panels show when you load the page
- [x] Load an existing simulation
- [x] Confirm no panels are showing when simulation loads
- [x] Confirm all buttons work appropriately
- [x] Confirm selecting a body opens the body panel 
- [x] Confirm selecting a note closes the body panel and opens the note panel
- [x] Confirm toggling the orbit tracker closes any open panel.
- [x] Confirm selecting a body while tracker is open does not show body data
  panel.

References
----------

- Closes #183
- Closes #141 
- Closes #72 
- @aaroncameron21 Would you like to confirm the panels operate as you would
  expect?