### PR TITLE
Add Note Persistance

### DIFF
--- a/src/bridge/controllers/SimulationController.js
+++ b/src/bridge/controllers/SimulationController.js
@@ -13,17 +13,22 @@
  */
 
 angular.module('bridge.controllers')
-  .controller('simulationController', ['$scope', 'eventPump', '$routeParams', 'simulator', 'Simulation', function($scope, eventPump, $routeParams, simulator, Simulation) {
+  .controller('simulationController', ['$scope', 'eventPump', '$routeParams', 'simulator', 'Simulation', 'SimulationNote', function($scope, eventPump, $routeParams, simulator, Simulation, SimulationNote) {
     $scope.simulationId = $routeParams.simulationId;
 
     Simulation.get({id: $scope.simulationId}, function(simulation) {
-      
+
       // Update the document title with the simulation title
       document.title = 'Oribitable - ' + simulation.title;
 
       // Update the simulator with the data
       simulator.reset(simulation.bodies);
+
+      SimulationNote.query({id: $scope.simulationId}, function(notes) {
+        simulator.reset(simulation.bodies, notes);
+        eventPump.step(false,true);
+      });
+
       eventPump.step(false,true);
     });
-  }
-  ]);
+  }]);

--- a/src/bridge/controllers/UserController.js
+++ b/src/bridge/controllers/UserController.js
@@ -13,7 +13,7 @@
  */
 
 angular.module('bridge.controllers')
-  .controller('userController', ['$routeParams', '$scope', 'eventPump', 'Simulation', 'simulator', 'User',  function($routeParams, $scope, eventPump, Simulation, simulator, User) {
+  .controller('userController', ['$routeParams', '$scope', 'eventPump', 'Simulation', 'SimulationNote', 'simulator', 'User',  function($routeParams, $scope, eventPump, Simulation, SimulationNote, simulator, User) {
     $scope.isPaused = () => eventPump.paused;
     $scope.User = User;
 
@@ -34,17 +34,30 @@ angular.module('bridge.controllers')
         Simulation.get({
           id: $routeParams.simulationId || 'random'},
           function(s) {
-            simulator.reset(s.bodies);
-            eventPump.step(false,true);
-            $('#body-sidebar').hide();
-            $('#note-sidebar').hide();
-            $('#tracker-sidebar').hide();
+            SimulationNote.query({id: s._id}, function(notes) {
 
-            // TODO: Global state is bad we need to resolve this
-            //
-            // Created issue [#93](https://github.com/orbitable/bridge/issues/93)
-            // to capture adding a composite object to collect rendering objects.
-            lineData = [];
+              simulator.reset(s.bodies, notes);
+              eventPump.step(false,true);
+              $('#body-sidebar').hide();
+              $('#note-sidebar').hide();
+              $('#tracker-sidebar').hide();
+
+              // TODO: Global state is bad we need to resolve this
+              //
+              // Created issue [#93](https://github.com/orbitable/bridge/issues/93)
+              // to capture adding a composite object to collect rendering objects.
+              lineData = [];
+            }, function() {
+              console.log('Unable to load notes');
+              simulator.reset(s.bodies);
+              $('#body-sidebar').hide();
+              $('#note-sidebar').hide();
+              $('#tracker-sidebar').hide();
+
+              lineData = [];
+            });
+          }, function() {
+            console.log('Unable to load simulation');
           });
       };
 

--- a/src/bridge/services/note.js
+++ b/src/bridge/services/note.js
@@ -1,0 +1,21 @@
+/* Copyright 2016 Orbitable Team Members
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+angular.module('bridge.services')
+  .factory('SimulationNote', ['$resource', function($resource) {
+    return $resource('//mission-control.orbitable.tech/simulations/:id/notes');
+  }])
+  .factory('Note', ['$resource', function($resource) {
+    return $resource('//mission-control.orbitable.tech/notes/:id');
+  }]);


### PR DESCRIPTION
Problem
-------

Notes are not saved alongside a simulation.

Solution
--------

Use the new notes endpoint available through mission control to save any notes alongside a simulation.

Howto Test
----------

**This is depdendent on a deploy of mission control after [https://github.com/orbitable/mission-control/pull/70](https://github.com/orbitable/mission-control/pull/70) is merged**.

- [x] Create a simulation
- [x] Add a note or two alongside your simulation
- [x] Save your simulation and notice success
- [x] Reload the page and confirm the created notes are present and function
  accordingly.
- [x] Share your simulation with the group to confirm notes are working as
  expected.

References
----------

- Closes #192
- @aaroncameron21