### PR TITLE
Add Units Service and Directive

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link href="node_modules/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="css/template.css" rel="stylesheet">
   </head>
-  <body class="fill-height">
+  <body class="fill-height" ng-controller='bodyController as b'>
     <nav class="navbar navbar-default navbar-fixed-top" ng-controller="navController">
       <div class="navbar-header">
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
@@ -38,7 +38,7 @@
         </ul>
       </div>
     </nav>
-    <div class="fill-height" ng-controller='bodyController as b' ng-view></div>
+    <div class="fill-height" ng-view></div>
     <div class="container narrow">
       <div id="settings" class="modal fade " tabindex="-1" role="dialog" >
         <div class="modal-dialog modal-sm">
@@ -66,22 +66,22 @@
                 <button type="button" class="btn btn-primary btn-sm" ng-click="b.updateStep()">Save</button>
                 <h2 class="form-settings-heading">Units</h2>
                 <label for="distance">Distance</label>
-                <select id="distance" ng-model="uDist" class="form-control">
+                <select id="distance" ng-model="Units.labels.distance" ng-change='b.updateUnits()' class="form-control">
                   <option value="m" selected="selected">Meters (m)</option>
                   <option value="km">Kilometers (km)</option>
                   <option value="au">Astronomical Units (au)</option>
                 </select>
                 <label for="mass">Mass</label>
-                <select id="mass" ng-model="uMass" class="form-control">
+                <select id="mass" ng-model="Units.labels.mass" ng-change='b.updateUnits()' class="form-control">
                   <option value="kg" selected="selected">Kilograms (kg)</option>
                   <option value="t">Metric ton (t)</option>
                   <option value="M">Solar Mass(M☉)</option>
                 </select>
                 <label for="time">Time</label>
-                <select ng-model="uTime" class="form-control">
+                <select ng-model="Units.labels.time" ng-change='b.updateUnits()' class="form-control">
                   <option value="s" selected="selected">Seconds (s)</option>
                   <option value="hr">Hours (hr)</option>
-                  <option value="y">Years (yr)</option>
+                  <option value="yr">Years (yr)</option>
                 </select>
               </form>
             </div>

--- a/partials/body-data.html
+++ b/partials/body-data.html
@@ -3,65 +3,65 @@
     <button type="button" class="close" aria-label="Close" ng-click="b.close()">
       <span>&times;</span>
     </button>
-    <h3 class="panel-title">{{editingBody.name}}</h3>
+    <h3 class="panel-title">{{selectedBody.name}}</h3>
   </div>
   <div class="panel-body">
     <form>
       <div class='form-group'>
         <label for='radius'>Radius</label>
         <div class='input-group'>
-          <input id='radius' type="number" class='form-control input-sm' 
-            ng-model="editingBody.radius" ng-change='b.updateBody(editingBody)' ng-readonly="b.getRunningState()">
-          <div class='input-group-addon'>km</div>
+          <input unit='distance' id='radius' type="number" class='form-control input-sm' 
+            ng-model="selectedBody.radius" ng-change='b.updateBody(selectedBody)' ng-readonly="b.getRunningState()">
+          <div class='input-group-addon'>{{ Units.labels.distance }}</div>
         </div>
       </div>
       <div class='form-group'>
         <label for='mass'>Mass</label>
         <div class='input-group'>
-          <input id='mass' type="number" class='form-control input-sm' 
-            ng-model="editingBody.mass"  ng-change='b.updateBody(editingBody)' ng-readonly="b.getRunningState()">
-          <div class='input-group-addon'>kg</div>
+          <input unit='mass' id='mass' type="number" class='form-control input-sm' 
+            ng-model="selectedBody.mass"  ng-change='b.updateBody(selectedBody)' ng-readonly="b.getRunningState()">
+          <div class='input-group-addon'>{{ Units.labels.mass }}</div>
         </div>
       </div>
       <div class='form-group'>
         <label for='luminosity'>Luminosity</label>
         <div class='input-group'>
           <input id='luminosity' type="number" class='form-control input-sm'
-            ng-model="editingBody.luminosity" ng-change='b.updateBody(editingBody)' ng-readonly="b.getRunningState()">
+            ng-model="selectedBody.luminosity" ng-change='b.updateBody(selectedBody)' ng-readonly="b.getRunningState()">
         </div>
       </div>
       <h4>Position</h4>
       <div class='form-group'>
         <div class='input-group'>
           <div class='input-group-addon'>x</div>
-          <input id='positionx' type="number" class='form-control input-sm'
-            ng-model="editingBody.position.x" ng-change='b.updateBody(editingBody)' ng-readonly="b.getRunningState()">
-          <div class='input-group-addon'>m</div>
+          <input unit='distance'  id='positionx' type="number" class='form-control input-sm'
+            ng-model="selectedBody.position.x" ng-change='b.updateBody(selectedBody)' ng-readonly="b.getRunningState()">
+          <div class='input-group-addon'>{{ Units.labels.distance }}</div>
         </div>
       </div>
       <div class='form-group'>
         <div class='input-group'>
           <div class='input-group-addon'>y</div>
-          <input id='positiony' type="number" class='form-control input-sm'
-            ng-model="editingBody.position.y" ng-change='b.updateBody(editingBody)' ng-readonly="b.getRunningState()">
-          <div class='input-group-addon'>m</div>
+          <input unit='distance' id='positiony' type="number" class='form-control input-sm'
+            ng-model="selectedBody.position.y" ng-change='b.updateBody(selectedBody)' ng-readonly="b.getRunningState()">
+          <div class='input-group-addon'>{{ Units.labels.distance }}</div>
         </div>
       </div>
       <h4>Velocity</h4>
       <div class='form-group'>
         <div class='input-group'>
           <div class='input-group-addon'>x</div>
-          <input id='velocityx' type="number" class='form-control input-sm'
-            ng-model="editingBody.velocity.x" ng-change='b.updateBody(editingBody)' ng-readonly="b.getRunningState()">
-          <div class='input-group-addon'>m/s</div>
+          <input unit='speed' id='velocityx' type="number" class='form-control input-sm'
+            ng-model="selectedBody.velocity.x" ng-change='b.updateBody(selectedBody)' ng-readonly="b.getRunningState()">
+          <div class='input-group-addon'>{{ Units.labels.speed }}</div>
         </div>
       </div>
       <div class='form-group'>
         <div class='input-group'>
           <div class='input-group-addon'>y</div>
-          <input id='velocityy' type="number" class='form-control input-sm'
-            ng-model="editingBody.velocity.y" ng-change='b.updateBody(editingBody)' ng-readonly="b.getRunningState()">
-          <div class='input-group-addon'>m/s</div>
+          <input unit='speed' id='velocityy' type="number" class='form-control input-sm'
+            ng-model="selectedBody.velocity.y" ng-change='b.updateBody(selectedBody)' ng-readonly="b.getRunningState()">
+          <div class='input-group-addon'>{{ Units.labels.speed }}</div>
         </div>
       </div>
     </form>

--- a/partials/note-data.html
+++ b/partials/note-data.html
@@ -1,35 +1,49 @@
 <div class="panel panel-default" ng-controller='noteController as n'>
   <div class="panel-heading text-center">
-    <button type="button" class="close" aria-label="Close" ng-click="n.closePanel()"><span>&times;</span></button>
+    <button type="button" class="close" aria-label="Close" ng-click="n.closePanel()"><label>&times;</span></button>
       Note
   </div>
   <div class="panel-body">
-    <div class="input-group">
-      <span class="input-group-addon" id="title-input">Title:</span>
-      <input type="text" class="form-control" placeholder="{{selectedNote.title}}" aria-describedby="title-input" ng-model="selectedNote.title" ng-change="n.updateNote()">
-    </div><br>
-    <div class="input-group">
-      <span class="input-group-addon" id="text-input">Text:</span>
-      <textarea type="text" rows = "3" class="form-control" placeholder="{{selectedNote.text}}" aria-describedby="text-input" ng-model="selectedNote.text" ng-change="n.updateNote()"></textarea>
-    </div><br>
-    <div class="input-group">
-      <span class="input-group-addon" id="startTime-input">Start Time:</span>
-      <input type="text" class="form-control" placeholder="{{selectedNote.startTime}}" aria-describedby="startTime-input" ng-model="selectedNote.startTime" ng-change="n.updateNote()">
-    </div><br>
-    <div class="input-group">
-      <span class="input-group-addon" id="duration-input">Duration:</span>
-      <input type="text" class="form-control" placeholder="{{selectedNote.duration}}" aria-describedby="duration-input" ng-model="selectedNote.duration" ng-change="n.updateNote()">
-    </div><br>
-    <div class="input-group">
-      <span class="input-group-addon" id="positionX-input">Position X:</span>
-      <input type="text" class="form-control" placeholder="{{selectedNote.position.x}}" aria-describedby="positionX-input" ng-model="selectedNote.position.x" ng-change="n.updateNote()">
-    </div>
-    <div class="input-group">
-      <span class="input-group-addon" id="positionY-input">Position Y:</span>
-      <input type="text" class="form-control" placeholder="{{selectedNote.position.y}}" aria-describedby="positionY-input" ng-model="selectedNote.position.y" ng-change="n.updateNote()">
-    </div><br>
-    <div class="text-center"><button type="button" class="btn btn-default btn" ng-click="n.removeNote(selectedNote.id)">
-      <span class="glyphicon glyphicon-trash"></span> </button> 
-    </div>
+    <form>
+      <div class='form-group'>
+        <label id="title-input">Title</label>
+        <input type="text" class="form-control input-sm" placeholder="{{selectedNote.title}}" aria-describedby="title-input" ng-model="selectedNote.title" ng-change="n.updateNote()">
+      </div>
+      <div class='form-group'>
+        <label id="text-input">Text</label>
+        <textarea rows = "3" class="form-control" placeholder="{{selectedNote.text}}" aria-describedby="text-input" ng-model="selectedNote.text" ng-change="n.updateNote()"></textarea>
+      </div>
+      <div class='form-group'>
+        <label id="startTime-input">Start Time</label>
+        <div class="input-group">
+          <input unit='time' type="text" class="form-control input-sm" placeholder="{{selectedNote.startTime}}" aria-describedby="startTime-input" ng-model="selectedNote.startTime" ng-change="n.updateNote()">
+          <div class='input-group-addon'>{{ Units.labels.time }}</div>
+        </div>
+      </div>
+      <div class='form-group'>
+        <label id="duration-input">Duration</label>
+        <div class="input-group">
+          <input unit='time' type="text" class="form-control input-sm" placeholder="{{selectedNote.duration}}" aria-describedby="duration-input" ng-model="selectedNote.duration" ng-change="n.updateNote()">
+          <div class='input-group-addon'>{{ Units.labels.time }}</div>
+        </div>
+      </div>
+      <div class='form-group'>
+        <label id="positionX-input">Position X</label>
+        <div class="input-group">
+          <input unit='distance' type="text" class="form-control input-sm" placeholder="{{selectedNote.position.x}}" aria-describedby="positionX-input" ng-model="selectedNote.position.x" ng-change="n.updateNote()">
+          <div class='input-group-addon'>{{ Units.labels.distance }}</div>
+        </div>
+      </div>
+      <div class='form-group'>
+        <label id="positionY-input">Position Y</label>
+        <div class="input-group">
+          <input unit='distance' type="text" class="form-control input-sm"placeholder="{{selectedNote.position.y}}" aria-describedby="positionY-input" ng-model="selectedNote.position.y" ng-change="n.updateNote()">
+          <div class='input-group-addon'>{{ Units.labels.distance }}</div>
+        </div>
+      </div>
+      <div class="text-center"><button type="button" class="btn btn-default btn" ng-click="n.removeNote(selectedNote.id)">
+        <span class="glyphicon glyphicon-trash"></span> </button> 
+      </div>
+    </form>
   </div>
 </div>

--- a/partials/simulation.html
+++ b/partials/simulation.html
@@ -43,7 +43,8 @@
                     <br>
                     Orbits Completed: {{simulator.orbitTracker.orbitCount}}
                     <br>
-                    Average Time: {{simulator.orbitTracker.orbitTime}}
+                    Average Time:
+                    {{Units.timeFromSim(simulator.orbitTracker.orbitTime).toPrecision(3)}} ({{ Units.labels.time }})
                     <br>
                     Range: {{simulator.orbitTracker.timeRange.toPrecision(3)}}%
                     <br>
@@ -85,8 +86,8 @@
                   <li ng-show="User.current"><a href="#/u/{{User.current.username}}">My Simulations</a></li>
                 </ul>
               </div>
-              <button type="button" class="btn btn-default btn-lg" data-toggle="modal"
-                                                                   data-target="#settings">
+              <button type="button" class="btn btn-default btn-lg"
+                data-toggle="modal" data-target="#settings" ng-click='b.close()'>
                 <span class="glyphicon glyphicon-cog"></span>
           </div>
         </li>

--- a/src/bridge/controllers/BodyController.js
+++ b/src/bridge/controllers/BodyController.js
@@ -13,16 +13,13 @@
  */
 
 angular.module('bridge.controllers')
-  .controller('bodyController', ['$scope', 'eventPump', 'simulator', 'User', function($scope, eventPump, simulator, User) {
+  .controller('bodyController', ['$scope', 'eventPump', 'simulator', 'Units', 'User', function($scope, eventPump, simulator, Units, User) {
     $scope.trackerPanel = {isOpen: false};
 
     $scope.timestep = 40000;
     $scope.timestepUnits = 'seconds';
-    $scope.uDist = 'm';
-    $scope.uMass = 'kg';
-    $scope.uTime = 's';
-    $scope.uLum  = 'L';
     $scope.simulator = simulator;
+    $scope.Units = Units;
     
     this.getRunningState = function() {
       return !eventPump.paused;

--- a/src/bridge/directives/br-fps-counter.js
+++ b/src/bridge/directives/br-fps-counter.js
@@ -15,12 +15,12 @@
 var angular = require('angular');
 
 angular.module('bridge.directives')
-  .directive('counter', ['$interval', 'eventPump', function($interval, eventPump) {
+  .directive('counter', ['eventPump', 'Units', function(eventPump, Units) {
 
     function link(scope, element) {
      
       var updateCallback = eventPump.register(function() {
-        element.text(Math.round(eventPump.simulator.simulationTime) + " seconds");
+        element.text(Units.timeFromSim(eventPump.simulator.simulationTime).toFixed(3) + " " + Units.labels.time);
       });
 
       element.on('destroy', function() {

--- a/src/bridge/directives/simulation/bodies.js
+++ b/src/bridge/directives/simulation/bodies.js
@@ -7,7 +7,6 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
     link: function(scope, elem) {
       // TODO: Properly resolve the initial resolution of selected body
       scope.selectedBody = {};
-      scope.editingBody = {};
       scope.selectedNote = {};
 
       // Stores the timestamp when a drag starts
@@ -59,21 +58,19 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
         });  
 
       function update(data) {
-        
         if (typeof scope.selectedBody.copy == 'function' && !eventPump.paused) {
-          scope.editingBody = scope.selectedBody.copy();
 
-          if (scope.editingBody.position) {
-            document.getElementById('positionx').value = scope.editingBody.position.x;
-            document.getElementById('positiony').value = scope.editingBody.position.y;
+          if (scope.selectedBody.position) {
+            document.getElementById('positionx').value = scope.selectedBody.position.x;
+            document.getElementById('positiony').value = scope.selectedBody.position.y;
           }
 
-          if (scope.editingBody.velocity) {
-            document.getElementById('velocityx').value = scope.editingBody.velocity.x;
-            document.getElementById('velocityy').value = scope.editingBody.velocity.y;
+          if (scope.selectedBody.velocity) {
+            document.getElementById('velocityx').value = scope.selectedBody.velocity.x;
+            document.getElementById('velocityy').value = scope.selectedBody.velocity.y;
           }
         }
-           
+
         function isSelectedBody(body) {
           if (body && scope.selectedBody ) {
             return body.id === scope.selectedBody.id;
@@ -112,7 +109,6 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
             .on('mousedown', function(d) {
               d3.event.stopPropagation();
               scope.selectedBody = d;
-              scope.editingBody = scope.selectedBody.copy();
               simulator.selectedBody = d;
               scope.selectedNote = {};
               eventPump.step(false,true);

--- a/src/bridge/directives/units.js
+++ b/src/bridge/directives/units.js
@@ -26,6 +26,8 @@ angular.module('bridge.directives')
               return Units.distanceToSim(data);
             case 'mass':
               return Units.massToSim(data);
+            case 'time':
+              return Units.timeToSim(data);
             default:
               return data;
           }
@@ -38,6 +40,8 @@ angular.module('bridge.directives')
               return Units.distanceFromSim(data);
             case 'mass':
               return Units.massFromSim(data);
+            case 'time':
+              return Units.timeFromSim(data);
             default:
               return data;
           }

--- a/src/bridge/directives/units.js
+++ b/src/bridge/directives/units.js
@@ -1,0 +1,47 @@
+/* Copyright 2016 Orbitable Team Members
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+var angular = require('angular');
+
+angular.module('bridge.directives')
+  .directive('unit', ['Units', function(Units) {
+    return {
+      require: 'ngModel',
+      link: function(scope, element, attrs, ngModelController) {
+        ngModelController.$parsers.push(function(data) {
+          //convert data from view format to model format
+          switch (attrs.unit) {
+            case 'distance':
+              return Units.distanceToSim(data);
+            case 'mass':
+              return Units.massToSim(data);
+            default:
+              return data;
+          }
+        });
+
+        ngModelController.$formatters.push(function(data) {
+          //convert data from model format to view format
+          switch (attrs.unit) {
+            case 'distance':
+              return Units.distanceFromSim(data);
+            case 'mass':
+              return Units.massFromSim(data);
+            default:
+              return data;
+          }
+        });
+      }
+    };
+  }]);

--- a/src/bridge/services/units.js
+++ b/src/bridge/services/units.js
@@ -70,6 +70,16 @@ angular.module('bridge.services')
           default:
             return d;
         }
+      },
+      timeToSim: function(d) {
+        switch (this.labels.time) {
+          case 'hr':
+            return d * (60 * 60);
+          case 'yr':
+            return d * (60 * 60 * 24 * 365);
+          default:
+            return d;
+        }
       }
     };
   });

--- a/src/bridge/services/units.js
+++ b/src/bridge/services/units.js
@@ -1,0 +1,75 @@
+/* Copyright 2016 Orbitable Team Members
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+angular.module('bridge.services')
+  .factory('Units', function($resource) {
+    return {
+      labels: {
+        distance: 'm',
+        mass: 'kg',
+        time: 's',
+        speed: 'm/s'
+      },
+      distanceFromSim: function(d) {
+        switch (this.labels.distance) {
+          case 'km':
+            return d / 1000;
+          case 'au':
+            return d / 149597870700;
+          default:
+            return d;
+        }
+      },
+      distanceToSim: function(d) {
+        switch (this.labels.distance) {
+          case 'km':
+            return 1000 * d;
+          case 'au':
+            return 149597870700 * d;
+          default:
+            return d;
+        }
+      },
+      massFromSim: function(d) {
+        switch (this.labels.mass) {
+          case 't':
+            return d / 1000;
+          case 'M':
+            return d / 1988435000000000000000000000000;
+          default:
+            return d;
+        }
+      },
+      massToSim: function(d) {
+        switch (this.labels.mass) {
+          case 't':
+            return d * 1000;
+          case 'M':
+            return d * 1988435000000000000000000000000;
+          default:
+            return d;
+        }
+      },
+      timeFromSim: function(d) {
+        switch (this.labels.time) {
+          case 'hr':
+            return d / (60 * 60);
+          case 'yr':
+            return d / (60 * 60 * 24 * 365);
+          default:
+            return d;
+        }
+      }
+    };
+  });


### PR DESCRIPTION
Problem
-------

The user selectable units are non functional as the model for body data has been shifted.

Solution
--------

A unit directive allows a for element to parse and cast a raw model data value into a derived value based on a selected unit set in the Units service. This allows the form to show the value of the simulation in different units without haveing to convert within the simulator.

Howto Test
----------

- [x] Open Units
- [x] Change units around
- [x] Notice UX updates in
  - [x] Counter
  - [x] Body Panel
  - [x] Note Panel
- [x] Update values in given units
- [x] Switch units again
- [x] Notice updated values are recasted in other units

References
----------

- Closes #176
- @mkinsey This adds bidirectional unit application to input fields.