### PR TITLE
Quick fix to ensure visual radius is accurate

### DIFF
--- a/src/bridge/directives/simulation/simulation.js
+++ b/src/bridge/directives/simulation/simulation.js
@@ -36,7 +36,7 @@ angular.module('bridge.directives')
           }
           
           scope.rScale = function(r) {
-            return (Math.log((r + 14961) / 14960)) / Math.LN10
+            return Math.max((Math.log((r + 14961) / 14960)) / Math.LN10,scope.xScale(r));
 
           }
 


### PR DESCRIPTION
Previously, there were issues with large-radius bodies where the visual representation of the body on screen was smaller than the space that the actual body occupied. This caused other bodies to 'collide' with it while appearing to be far away from it. 

This fix ensures that the visual representation of the body is no smaller than its collision bounds.

To test:
* Set the center body to larger radii
* Run the simulation and ensure that bodies are not destroyed until they at least make visual contact with the large body.

_____
* Closes #209