### PR TITLE
Adds selector directive

### DIFF
--- a/partials/simulation-directive.html
+++ b/partials/simulation-directive.html
@@ -4,6 +4,7 @@
     <g habitable-zones></g>
     <g paths></g>
     <g vectors></g>
+    <g select-marker></g>
     <g id='bodies' bodies></g>
     <g ruler></g>
   </g>

--- a/src/bridge/directives/simulation/bodies.js
+++ b/src/bridge/directives/simulation/bodies.js
@@ -91,20 +91,20 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
             .attr('cy', (d) => scope.yScale(d.position.y))
             .attr('r',  (d) => scope.rScale(d.radius))
             .attr('fill', (d) => d.color)
-            .attr('stroke', (d) => ( isSelectedBody(d) ? 'white' : 'darkgrey' ))
-            .attr('stroke-width',(d) => ( isSelectedBody(d) ? (scope.rScale(d.radius) + 30) : 0 ))
+            // .attr('stroke', (d) => ( isSelectedBody(d) ? 'white' : 'darkgrey' ))
+            // .attr('stroke-width',(d) => ( isSelectedBody(d) ? (scope.rScale(d.radius) + 30) : 0 ))
             .call(drag)
             .on('mouseover',function() {
               d3.select(this)
                 .transition()
                 .duration(500)
-                .attr('stroke-width',(d) => scope.rScale(d.radius) + 30);
+                .attr('r',(d) => scope.rScale(d.radius) + 10);
             })
           .on('mouseout',function() {
             d3.select(this)
               .transition()
               .duration(500)
-              .attr('stroke-width',(d) => ( isSelectedBody(d) ? (scope.rScale(d.radius) + 30) : 0 ));
+              .attr('r',(d) =>  scope.rScale(d.radius) );
             })
             .on('mousedown', function(d) {
               d3.event.stopPropagation();

--- a/src/bridge/directives/simulation/selector.js
+++ b/src/bridge/directives/simulation/selector.js
@@ -1,0 +1,38 @@
+var angular = require('angular');
+var d3 = require('d3');
+
+angular.module('bridge.directives')
+  .directive('selectMarker', ['eventPump', 'simulator', function(eventPump, simulator) {
+    return {
+      link: function(scope, elem) {
+        var selectorGroup = d3.select(elem[0]);
+        function update(data) {
+          // A conditional function that asserts if a body has a habitable zone
+          var isSelected = (body) => body.id === scope.selectedBody.id;
+          var selector = selectorGroup
+            .selectAll('circle')
+            .data(data.filter(isSelected));
+
+          function drawSelector(selector) {
+
+            //draw habitable zone around star (divide radius by the scale of the radius (for now its assumed to be 10^8))
+            selector
+               .attr('id', "select-marker")
+               .attr('cx', (d) => scope.xScale(d.position.x))
+               .attr('cy', (d) => scope.yScale(d.position.y))
+               .attr('r', (d) => scope.rScale(d.radius) + 10)
+               .attr('fill-opacity', 0)
+               .attr('stroke','white')
+               .attr('stroke-width', (d) => scope.rScale(d.radius))
+               .attr('stroke-opacity', 0.5);
+          }
+
+          drawSelector(selector);
+          drawSelector(selector.enter().append('circle'));
+          selector.exit().remove();
+        }
+
+        eventPump.register(() => update(simulator.bodies));
+      }
+    };
+  }]);


### PR DESCRIPTION
Instead of using the bodies' 'stroke' attribute to indicate selected bodies, I've added a directive to do something similar. This prevents visual issues when using browsers that handle the stroke attribute differently.
To test:
- [x] Open in your choice of browser
- [x] Hover over a body, ensure it gets bigger
- [x] Click a body, ensure a selection ring appears
- [x] Repeat with other browsers and ensure it looks the same


___
* Closes #214