### PR TITLE
Unify Simulation Reset

### DIFF
--- a/src/bridge/controllers/UserController.js
+++ b/src/bridge/controllers/UserController.js
@@ -16,55 +16,41 @@ angular.module('bridge.controllers')
   .controller('userController', ['$routeParams', '$scope', 'eventPump', 'Simulation', 'SimulationNote', 'simulator', 'User',  function($routeParams, $scope, eventPump, Simulation, SimulationNote, simulator, User) {
     $scope.isPaused = () => eventPump.paused;
     $scope.User = User;
-    
-    $(function () {
-      $('[data-toggle="tooltip"]').tooltip()
-    })
-    
+
+    $(function() {
+      $('[data-toggle="tooltip"]').tooltip();
+    });
+
+    var reset = function(b, n) {
+      simulator.reset(b, n);
+      eventPump.step(false,true);
+
+      $('#body-sidebar').hide();
+      $('#note-sidebar').hide();
+      $('#tracker-sidebar').hide();
+
+      lineData = [];
+    };
 
     this.togglePlay = function() {
         $scope.isPaused() ? eventPump.resume() : eventPump.pause();
       };
-      
-      this.newSimulation = function() {
-        simulator.reset();
-        eventPump.step(false,true);
-      };
-      
+
+    this.newSimulation = function() {
+      eventPump.pause();
+      reset();
+    };
+
     this.paused = function() {
-        return eventPump.paused;
+      return eventPump.paused;
     };
 
     this.refresh = function() {
-        Simulation.get({
-          id: $routeParams.simulationId || 'random'},
-          function(s) {
-            SimulationNote.query({id: s._id}, function(notes) {
-
-              simulator.reset(s.bodies, notes);
-              eventPump.step(false,true);
-              $('#body-sidebar').hide();
-              $('#note-sidebar').hide();
-              $('#tracker-sidebar').hide();
-
-              // TODO: Global state is bad we need to resolve this
-              //
-              // Created issue [#93](https://github.com/orbitable/bridge/issues/93)
-              // to capture adding a composite object to collect rendering objects.
-              lineData = [];
-            }, function() {
-              console.log('Unable to load notes');
-              simulator.reset(s.bodies);
-              $('#body-sidebar').hide();
-              $('#note-sidebar').hide();
-              $('#tracker-sidebar').hide();
-
-              lineData = [];
-            });
-          }, function() {
-            console.log('Unable to load simulation');
-          });
-      };
+      Simulation.get({
+        id: $routeParams.simulationId || 'random'},
+          (s) => SimulationNote.query({id: s._id}, (n) => reset(s.bodies, n), () => reset(s)),
+          (s)  => console.log('Unable to load simulation'));
+    };
 
     this.ruler = function() {
         var btn = document.getElementById('btn_ruler');


### PR DESCRIPTION
Problem
-------

When a new simulation is created the existing paths are not wiped causing the exisiting paths to be reattributed to the new bodies causing strange path issues.

Solution
--------

Write a single handler for simulation loading and use it in both new simualation as well as resets agains the end. This ensures the logic lives in one place and changes to one will affect all applicable instances.

Howto Test
----------

- [x] Resetting the simulation works as expected
- [x] Select some bodies
- [x] Let some paths be drawn by playing the simulation
- [x] Click the new simulation button
- [x] The paths should be gone when it loads
- [x] The new simulation should be paused

Reference
---------

- Closes #204 