### PR TITLE
Update Scope with Zoom or Pan Event

### DIFF
--- a/src/bridge/directives/simulation/axis.js
+++ b/src/bridge/directives/simulation/axis.js
@@ -32,6 +32,7 @@ angular.module('bridge.directives')
           .call(yAxis);
 
         scope.zoom.on('zoom', function() {
+          scope.$apply();
           scope.svg.select('.x.axis').call(xAxis);
           scope.svg.select('.y.axis').call(yAxis);
         });

--- a/src/bridge/directives/simulation/simulation.js
+++ b/src/bridge/directives/simulation/simulation.js
@@ -9,7 +9,12 @@ angular.module('bridge.directives')
           var svgElem = elem.find('svg')[0];
           var translationGroup = d3.select('#translation');
 
+          var dragUpdate = d3.behavior.drag()
+            .on('drag', () => scope.$apply());
+          
           scope.svg = d3.select(svgElem);
+
+          scope.svg.call(dragUpdate);
 
           scope.height = svgElem.clientHeight;
           scope.width = svgElem.clientWidth;
@@ -26,34 +31,32 @@ angular.module('bridge.directives')
 
           scope.xScale = Scale.x;
           scope.yScale = Scale.y;
-          
+
           scope.xTransform = function(x) {
             return scope.xScale(x) * scope.zoom.scale() + scope.zoom.translate()[0];
-          }
-          
+          };
+
           scope.yTransform = function(y) {
             return scope.yScale(y) * scope.zoom.scale() + scope.zoom.translate()[1];
-          }
-          
-          scope.rScale = function(r) {
-            return Math.max((Math.log((r + 14961) / 14960)) / Math.LN10,scope.xScale(r));
+          };
 
-          }
+          scope.rScale = function(r) {
+            return Math.max((Math.log((r + 14961) / 14960)) / Math.LN10, scope.xScale(r));
+          };
 
           scope.zoom = d3.behavior.zoom()
             .x(scope.windowXScale)
             .y(scope.windowYScale)
             .scaleExtent([0.1, 6]); // TODO: Pass scale extent as attributes
-            
 
           scope.zoom.on('zoom.translation', function() {
             translationGroup.attr('transform',
               'translate(' + d3.event.translate + ') scale(' + d3.event.scale + ')');
           });
-          
+
           scope.svg.call(scope.zoom.translate(scope.windowCenter).event);
           scope.svg.call(scope.zoom);
-          
+
         }
       },
       templateUrl: 'partials/simulation-directive.html'


### PR DESCRIPTION
Problem
-------

Some objects which depend on scope value changes for positioning info are not
being redrawn when the canvas is panned or zoomed.

Solution
--------

The scope is never updated in these events causing angular to never re render
anything. By forcing an apply on top level pans and zooms all of the dependent
objects are updated.

Howto Test
----------

- [x] Create or load a simulation with notes
- [x] Notice notes are rendered on the plane
- [x] Pan the plane and notice notes move with it
- [x] Zoom the plane and ntoice notes zoom with it

References
----------

- Closes #203