### PR TITLE
Add Reset Interceptors for Path Resetting

### DIFF
--- a/src/bridge/controllers/UserController.js
+++ b/src/bridge/controllers/UserController.js
@@ -34,8 +34,6 @@ angular.module('bridge.controllers')
       $('#tracker-sidebar').hide();
       $('#add-group').prop( "disabled", false );
       $('#btn_save').prop( "disabled", false );
-
-      lineData = [];
     };
 
     this.togglePlay = function() {
@@ -71,7 +69,6 @@ angular.module('bridge.controllers')
         $('#tracker-sidebar').hide();
         $('#add-group').prop( "disabled", false );
         $('#btn_save').prop( "disabled", false );
-        lineData = [];
       }
 
     };

--- a/src/bridge/directives/simulation/bodies.js
+++ b/src/bridge/directives/simulation/bodies.js
@@ -1,7 +1,7 @@
 var angular = require('angular');
 var d3 = require('d3');
 
-var BodiesDirective = function(eventPump, simulator, Scale, User) {
+var BodiesDirective = function(eventPump, Paths, simulator, Scale, User) {
   return {
     scope: false,
     link: function(scope, elem) {
@@ -125,9 +125,9 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
                 $('#note-sidebar').hide();
               }
 
-              lineData.push({body: d, data: []});
-              if (lineData.length > lineMaxCount) {
-                lineData.shift();
+              Paths.data.push({body: d, data: []});
+              if (Paths.data.length > lineMaxCount) {
+                Paths.data.shift();
               }
             });
 
@@ -204,7 +204,7 @@ var BodiesDirective = function(eventPump, simulator, Scale, User) {
 };
 
 // List dependencies to be injected
-BodiesDirective.$inject = ['eventPump', 'simulator', 'Scale', 'User'];
+BodiesDirective.$inject = ['eventPump', 'Paths', 'simulator', 'Scale', 'User'];
 
 // Register Directive
 angular.module('bridge.directives')

--- a/src/bridge/directives/simulation/paths.js
+++ b/src/bridge/directives/simulation/paths.js
@@ -1,8 +1,6 @@
 var angular = require('angular');
 var d3 = require('d3');
 
-// TODO: This is bad; Correct it
-var lineData = [];
 var lineID = 0;
 var lineMaxCount = 5;
 var delayVal = 10;
@@ -10,7 +8,7 @@ var delayCount = 0;
 var MAX_PATH = 300;
 
 angular.module('bridge.directives')
-  .directive('paths', ['eventPump', 'simulator', function(eventPump, simulator) {
+  .directive('paths', ['eventPump', 'Paths', 'simulator', function(eventPump, Paths, simulator) {
     return {
       link: function(scope, elem) {
         var pathsGroup = d3.select(elem[0]);
@@ -52,33 +50,30 @@ angular.module('bridge.directives')
           paths.exit().remove();
         }
 
-        eventPump.register(() => update(lineData));
+        eventPump.register(() => update(Paths.data));
         eventPump.register(function() {
-          
-          
-            lineData.forEach(function(path) {
-                path.data.pop();
-                path.data.push({
-                  x: scope.xScale(path.body.position.x),
-                  y: scope.yScale(path.body.position.y),
-                });
+          Paths.data.forEach(function(path) {
+            path.data.pop();
+            path.data.push({
+              x: scope.xScale(path.body.position.x),
+              y: scope.yScale(path.body.position.y),
             });
+          });
 
           if (delayCount > delayVal) {
-            
-            lineData.forEach(function(path) {
+            Paths.data.forEach(function(path) {
               path.data.color = path.body.color;
-                if (path.data.length > MAX_PATH) {
-                  path.data.shift();
-                }
-                path.data.push({
-                  x: scope.xScale(path.body.position.x),
-                  y: scope.yScale(path.body.position.y),
-                });
-                
+
+              if (path.data.length > MAX_PATH) {
+                path.data.shift();
+              }
+
+              path.data.push({
+                x: scope.xScale(path.body.position.x),
+                y: scope.yScale(path.body.position.y),
+              });
+
             });
-            
-            //console.log(lineData);
 
             delayCount = 0;
           }

--- a/src/bridge/services/paths.js
+++ b/src/bridge/services/paths.js
@@ -1,0 +1,20 @@
+/* Copyright 2016 Orbitable Team Members
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+angular.module('bridge.services')
+  .factory('Paths', function() {
+    return {
+      data: []
+    };
+  });

--- a/src/bridge/services/simulator.js
+++ b/src/bridge/services/simulator.js
@@ -16,7 +16,7 @@ var angular = require('angular');
 var Simulator = require('engine');
 
 angular.module('bridge.services')
-  .factory('simulator', ["eventPump", function(eventPump) {
+  .factory('simulator', ['eventPump', 'Paths', function(eventPump, Paths) {
     var simulator = new Simulator();
     eventPump.simulator = simulator;
     eventPump.timestep = 40000;
@@ -28,6 +28,17 @@ angular.module('bridge.services')
       // irregardless of FSP.
       simulator.update(eventPump.timestep);
     });
+
+    var pathResetIntercept = function(fn) {
+      return function() {
+        Paths.data = [];
+        return fn.apply(this, arguments);
+      };
+    };
+
+    // Intercept calls to reset and remove path data
+    simulator.reset = pathResetIntercept(simulator.reset);
+    simulator.resetLocal = pathResetIntercept(simulator.resetLocal);
 
     return simulator;
   }]);


### PR DESCRIPTION
Problem
-------

Path data can be left in strange states which leaves path artifacts on the
screen.

Solution
--------

Remove paths from the global namespace and add them as a service. In additon
interceptors around the simulation reset and resetLocal calls allow the path
data to be reset in cordination with these function calls. This ensures the path
data is reset any time the simulation bodies move outside of a update call.

Howto Test
----------

- [x] Load a simulation with bodies
- [x] Setup some paths and confirm they work as expected
- Reset locally
  - [x] Create some paths
  - [x] Reset locally
  - [x] Confirm paths reset
- Reset from server
  - [x] Create some paths
  - [x] Reset by reloading from server
  - [x] Confirm paths reset
- Reset by selecting another simulation
  - [x] Create some paths
  - [x] Reset by loading list of simulations and choosing another simulation
  - [x] Confirm paths reset

References
----------

- Closes #237