### PR TITLE
Add line to visualize orbit tracker

### DIFF
--- a/partials/simulation-directive.html
+++ b/partials/simulation-directive.html
@@ -2,6 +2,7 @@
   <g axis></g>
   <g id=translation>
     <g habitable-zones></g>
+    <g tracker-line></g>
     <g select-marker></g>
     <g paths></g>
     <g vectors></g>

--- a/src/bridge/controllers/trackerController.js
+++ b/src/bridge/controllers/trackerController.js
@@ -21,6 +21,7 @@ angular.module('bridge.controllers')
             $scope.simulator.selectedBody,
             $scope.simulator.simulationTime
         );
+        eventPump.step(false,true);
     };
 
     this.selectTargetBody = function(){
@@ -28,11 +29,13 @@ angular.module('bridge.controllers')
             $scope.simulator.selectedBody,
             $scope.simulator.simulationTime
         );
+        eventPump.step(false,true);
     };
     
     this.setState = function(state){
         $scope.simulator.orbitTracker.setState(state,$scope.simulator.simulationTime);
         this.updateCallback();
+        eventPump.step(false,true);
     };
     
     this.getState = function() {

--- a/src/bridge/directives/simulation/tracker-line.js
+++ b/src/bridge/directives/simulation/tracker-line.js
@@ -1,0 +1,41 @@
+var angular = require('angular');
+var d3 = require('d3');
+
+angular.module('bridge.directives')
+  .directive('trackerLine', ['eventPump', 'simulator', function(eventPump, simulator) {
+    return {
+      link: function(scope, elem) {
+        var selectorGroup = d3.select(elem[0]);
+        function update(data) {
+          // A conditional function that asserts if a body has a habitable zone
+          var isCenter = (body) => body.id === (simulator.orbitTracker.centerBody || {id: -1}).id;
+          var getTargetBody = () => simulator.orbitTracker.targetBody || {position: {x:0,y:0}};
+          
+          var selector = selectorGroup
+            .selectAll('line')
+            .data(data.filter(isCenter));
+
+          function drawSelector(selector) {
+
+            //draw habitable zone around star (divide radius by the scale of the radius (for now its assumed to be 10^8))
+            selector
+               .attr('id', "tracker-line")
+               .attr('x1', (d) => scope.xScale(d.position.x))
+               .attr('y1', (d) => scope.yScale(d.position.y))
+               .attr('x2', (d) => scope.xScale(getTargetBody().position.x))
+               .attr('y2', (d) => scope.xScale(getTargetBody().position.y))
+               .attr('stroke','white')
+               .attr('stroke-width', 3)
+               .attr('stroke-dasharray',"10, 5")
+               .attr('stroke-opacity', (simulator.orbitTracker.running ? 0.4 : 0.0));
+          }
+
+          drawSelector(selector);
+          drawSelector(selector.enter().append('line'));
+          selector.exit().remove();
+        }
+
+        eventPump.register(() => update(simulator.bodies));
+      }
+    };
+  }]);


### PR DESCRIPTION
Adds a visual component to the orbit tracker.

To Test:
- [ ] Use engine version 0.2.8
- [ ] Select bodies for tracker
- [ ] Run while tracking for a few seconds
- [ ] Make sure a dashed line is being drawn between selected bodies
- [ ] Pause and press stop, ensure the line disappears
- [ ] Select two bodies that aren't the center body and witness the shenanigans.

_____
* Closes #244